### PR TITLE
tests for core.loader.clj and small change v0.2

### DIFF
--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -33,7 +33,9 @@
   "find-n-filter namespaces based on a provided pattern"
   ([pattern] (find-namespaces pattern (all-namespaces)))
   ([pattern all-nss]
-   (filter #(re-matches pattern (str %)) all-nss)))
+   (->> all-nss
+        (filter #(re-matches pattern (str %)))
+        (distinct))))
 
 ; mycompany.plugins.commands.*
 (def all-command-plugins-regex #"^.*plugins\.commands.*")

--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -34,23 +34,28 @@
   [pattern]
   (filter #(re-matches pattern (str %)) (all-namespaces)))
 
+; mycompany.plugins.commands.*
+(def all-command-plugins-regex #"^.*plugins\.commands.*")
+
 (def yetibot-command-namespaces
   [;; support for e.g.:
    ;; yetibot.commands.*
    ;; yetibot.core.commands.*
    ;; yetibot-pluginname.commands.*
    #"^yetibot(\S*)\.(core\.)?commands.*"
-   ;; mycompany.plugins.commands.*
-   #"^.*plugins\.commands.*"
+   all-command-plugins-regex
    ])
 
 (comment
   (find-namespaces
     (first yetibot-command-namespaces)))
 
+; mycompany.plugins.observers.*
+(def all-observer-plugins-regex #"^.*plugins\.observers.*")
+
 (def yetibot-observer-namespaces
   [#"^yetibot\.(core\.)?observers.*"
-   #"^.*plugins\.observers.*"
+   all-observer-plugins-regex
    ])
 
 (comment
@@ -58,11 +63,10 @@
    (first yetibot-observer-namespaces)))
 
 (def yetibot-all-namespaces
-  (conj
-   (map last [yetibot-command-namespaces
-              yetibot-observer-namespaces])
-   ; with a negative lookahead assertion
-   #"^yetibot\.(.(?!(core)))*"))
+  (list all-command-plugins-regex
+        all-observer-plugins-regex
+        #"^yetibot\.(.(?!(core)))*"    ; with a negative lookahead assertion
+  ))
 
 (comment
   yetibot-all-namespaces

--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -28,7 +28,9 @@
    (ns/find-namespaces (cp/classpath))))
 
 (defn find-namespaces [pattern]
-  (filter #(re-matches pattern (str %)) (all-namespaces)))
+  (->> (all-namespaces)
+       (filter #(re-matches pattern (str %)))
+       (distinct)))
 
 (def yetibot-command-namespaces
   [;; support for e.g.:

--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -87,7 +87,7 @@
   [ns-patterns]
   (let [nss (flatten (map find-namespaces ns-patterns))]
     (info "☐ Loading" (count nss) "namespaces matching" ns-patterns)
-    (dorun (map load-ns nss))
+    (doseq [n nss] (load-ns n))
     (info "☑ Loaded" (count nss) "namespaces matching" ns-patterns)
     nss))
 

--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -39,21 +39,22 @@
    ;; yetibot-pluginname.commands.*
    #"^yetibot(\S*)\.(core\.)?commands.*"
    ;; mycompany.plugins.commands.*
-   #"^.*plugins\.commands.*"])
+   #"^.*plugins\.commands.*"
+   ])
 
 (comment
   (find-namespaces
-   (first yetibot-command-namespaces)))
+    (first yetibot-command-namespaces)))
 
 (def yetibot-observer-namespaces
   [#"^yetibot\.(core\.)?observers.*" #"^.*plugins\.observers.*"])
 
 (def yetibot-all-namespaces
   (merge
-   (map last [yetibot-command-namespaces
-              yetibot-observer-namespaces])
+    (map last [yetibot-command-namespaces
+               yetibot-observer-namespaces])
     ; with a negative lookahead assertion
-   #"^yetibot\.(.(?!(core)))*"))
+    #"^yetibot\.(.(?!(core)))*"))
 
 (defn load-ns [arg]
   (debug "Loading" arg)

--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -28,9 +28,7 @@
    (ns/find-namespaces (cp/classpath))))
 
 (defn find-namespaces [pattern]
-  (->> (all-namespaces)
-       (filter #(re-matches pattern (str %)))
-       (distinct)))
+  (filter #(re-matches pattern (str %)) (all-namespaces)))
 
 (def yetibot-command-namespaces
   [;; support for e.g.:

--- a/test/yetibot/core/test/commands/cmd.clj
+++ b/test/yetibot/core/test/commands/cmd.clj
@@ -3,8 +3,10 @@
    [midje.sweet :refer [fact => contains has-prefix just]]
    [matcher-combinators.midje :refer [match]]
    [yetibot.core.midje :refer [value data error]]
-   [yetibot.core.commands.cmd :refer [cmd]]))
+   [yetibot.core.commands.cmd :refer [cmd]]
+   [yetibot.core.loader :as loader]))
 
 (fact
  "cmd should work as expected"
+ (loader/load-commands)
  (cmd {:match "echo hi"}) => "hi")

--- a/test/yetibot/core/test/commands/cmd.clj
+++ b/test/yetibot/core/test/commands/cmd.clj
@@ -1,12 +1,9 @@
 (ns yetibot.core.test.commands.cmd
   (:require
-   [midje.sweet :refer [fact => contains has-prefix just]]
-   [matcher-combinators.midje :refer [match]]
-   [yetibot.core.midje :refer [value data error]]
+   [midje.sweet :refer [fact =>]]
    [yetibot.core.commands.cmd :refer [cmd]]
    [yetibot.core.loader :as loader]))
 
-(fact
- "cmd should work as expected"
- (loader/load-commands)
- (cmd {:match "echo hi"}) => "hi")
+(fact "cmd should work as expected"
+      (loader/load-commands)
+      (cmd {:match "echo hi"}) => "hi")

--- a/test/yetibot/core/test/loader.clj
+++ b/test/yetibot/core/test/loader.clj
@@ -20,8 +20,8 @@
              nss-count (count nss)]
          (fact "results is non-empty collection that contains expected namespace"
                nss => (every-checker coll? not-empty) (contains 'yetibot.core.commands.help))
-      ;;    (fact "results is exactly 2 commands"
-      ;;          nss-count => 2)
+         (fact "results is exactly 2 commands"
+               nss-count => 2)
          (fact "results don't contain extraneous namespaces"
                nss =not=> (contains 'yetibot.core.commands.echo))))
 

--- a/test/yetibot/core/test/loader.clj
+++ b/test/yetibot/core/test/loader.clj
@@ -20,8 +20,8 @@
              nss-count (count nss)]
          (fact "results is non-empty collection that contains expected namespace"
                nss => (every-checker coll? not-empty) (contains 'yetibot.core.commands.help))
-         (fact "results is exactly 2 commands"
-               nss-count => 2)
+      ;;    (fact "results is exactly 2 commands"
+      ;;          nss-count => 2)
          (fact "results don't contain extraneous namespaces"
                nss =not=> (contains 'yetibot.core.commands.echo))))
 

--- a/test/yetibot/core/test/loader.clj
+++ b/test/yetibot/core/test/loader.clj
@@ -1,11 +1,31 @@
 (ns yetibot.core.test.loader
-  (:require
-    [yetibot.core.loader :as loader]
-    [clojure.test :refer :all]))
+  (:require [yetibot.core.loader :as loader]
+            [midje.sweet :refer [=> =not=> contains fact facts every-checker]]))
 
-(deftest loader
-  (testing
-    "Loading all namespaces. This can help find invalid requires or errors in
-    code at test time (instead of waiting till runtime)"
-    (loader/load-observers)
-    (loader/load-commands)))
+(fact "all-namespaces returns non-empty collection that contains expected namespace"
+      (loader/all-namespaces)
+      => (every-checker coll? not-empty (contains 'yetibot.core.loader)))
+
+(facts "about load-ns"
+       (fact "loads a legit namesapce and returns said namespace"
+             (loader/load-ns 'yetibot.core.commands.help)
+             => 'yetibot.core.commands.help)
+       (fact "returns nil when loading illegitimate namespace"
+             (loader/load-ns 'i.am.fake) => nil))
+
+(facts "about find-and-load-namespaces"
+       (let [patterns '(#"yetibot\.core\.commands\.help"
+                        #"yetibot\.core\.commands\.error")
+             nss (loader/find-and-load-namespaces patterns)]
+         (fact "results is non-empty collection"
+               nss => (every-checker coll? not-empty))
+         (fact "results contain specific namespace"
+               nss => (contains 'yetibot.core.commands.help))
+         (fact "results don't contain extraneous namespaces"
+               nss =not=> (contains 'yetibot.core.commands.echo))))
+
+(fact "load-observers returns a non-empty collection"
+      (loader/load-observers) => (every-checker coll? not-empty))
+
+(fact "load-commands returns a non-empty collection"
+      (loader/load-commands) => (every-checker coll? not-empty))

--- a/test/yetibot/core/test/loader.clj
+++ b/test/yetibot/core/test/loader.clj
@@ -17,10 +17,8 @@
        (let [patterns '(#"yetibot\.core\.commands\.help"
                         #"yetibot\.core\.commands\.error")
              nss (loader/find-and-load-namespaces patterns)]
-         (fact "results is non-empty collection"
-               nss => (every-checker coll? not-empty))
-         (fact "results contain specific namespace"
-               nss => (contains 'yetibot.core.commands.help))
+         (fact "results is non-empty collection that contains expected namespace"
+               nss => (every-checker coll? not-empty) (contains 'yetibot.core.commands.help))
          (fact "results don't contain extraneous namespaces"
                nss =not=> (contains 'yetibot.core.commands.echo))))
 

--- a/test/yetibot/core/test/loader.clj
+++ b/test/yetibot/core/test/loader.clj
@@ -16,9 +16,12 @@
 (facts "about find-and-load-namespaces"
        (let [patterns '(#"yetibot\.core\.commands\.help"
                         #"yetibot\.core\.commands\.error")
-             nss (loader/find-and-load-namespaces patterns)]
+             nss (loader/find-and-load-namespaces patterns)
+             nss-count (count nss)]
          (fact "results is non-empty collection that contains expected namespace"
                nss => (every-checker coll? not-empty) (contains 'yetibot.core.commands.help))
+         (fact "results is exactly 2 commands"
+               nss-count => 2)
          (fact "results don't contain extraneous namespaces"
                nss =not=> (contains 'yetibot.core.commands.echo))))
 


### PR DESCRIPTION
- added new midje tests for loader.clj
- replaced existing clojure.test with midje tests
- found an odd issue where namespaces were being "double loaded" because dups of namespaces were being returned via the `find-namespaces` function .. not entirely sure why, so running `(distinct)` over list before returning
- loading YB commands in `test/cmd.clj` because it needs them after removing said command from `test/loader.clj` via `clojure.test`

🤞 🤞 
