### PR TITLE
changes to loader.clj to make kondo/codeclimate more happy

### DIFF
--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -1,6 +1,6 @@
 (ns yetibot.core.loader
   (:require
-   [taoensso.timbre :refer [debug info warn error]]
+   [taoensso.timbre :refer [debug info warn]]
    [yetibot.core.config :refer [get-config]]
    [clojure.spec.alpha :as s]
    [yetibot.core.spec :as yspec]
@@ -22,15 +22,22 @@
 (defn plugins-config []
   (get-config ::plugins-config [:plugins]))
 
-(defn all-namespaces []
+(defn all-namespaces
+  "find and return all namespaces found on the (system)classpath"
+  []
   (concat
    (ns/find-namespaces (cp/system-classpath))
    (ns/find-namespaces (cp/classpath))))
 
-(defn find-namespaces [pattern]
+(defn find-namespaces
+  "find-n-filter namespaces based on a provided pattern"
+  [pattern]
   (->> (all-namespaces)
        (filter #(re-matches pattern (str %)))
        (distinct)))
+
+; mycompany.plugins.commands.*
+(def all-command-plugins-regex #"^.*plugins\.commands.*")
 
 (def yetibot-command-namespaces
   [;; support for e.g.:
@@ -38,44 +45,71 @@
    ;; yetibot.core.commands.*
    ;; yetibot-pluginname.commands.*
    #"^yetibot(\S*)\.(core\.)?commands.*"
-   ;; mycompany.plugins.commands.*
-   #"^.*plugins\.commands.*"
+   all-command-plugins-regex
    ])
 
 (comment
   (find-namespaces
     (first yetibot-command-namespaces)))
 
+; mycompany.plugins.observers.*
+(def all-observer-plugins-regex #"^.*plugins\.observers.*")
+
 (def yetibot-observer-namespaces
-  [#"^yetibot\.(core\.)?observers.*" #"^.*plugins\.observers.*"])
+  [#"^yetibot\.(core\.)?observers.*"
+   all-observer-plugins-regex
+   ])
+
+(comment
+  (find-namespaces
+   (first yetibot-observer-namespaces)))
 
 (def yetibot-all-namespaces
-  (merge
-    (map last [yetibot-command-namespaces
-               yetibot-observer-namespaces])
-    ; with a negative lookahead assertion
-    #"^yetibot\.(.(?!(core)))*"))
+  ;; to mimic previous use of merge, using `list` vs `vector` -- not sure if matters
+  (list all-command-plugins-regex
+        all-observer-plugins-regex
+        #"^yetibot\.(.(?!(core)))*"    ; with a negative lookahead assertion
+  ))
+
+(comment
+  yetibot-all-namespaces
+  )
 
 (defn load-ns [arg]
   (debug "Loading" arg)
-  (try (require arg)
-       arg
-       (catch Exception e
-         (warn "WARNING: problem requiring" arg "hook:" (.getMessage e))
-         (st/print-stack-trace (st/root-cause e) 15))))
+  (try
+    (require arg)
+    arg
+    (catch Exception e
+      (warn "WARNING: problem requiring" arg "hook:" (.getMessage e))
+      (st/print-stack-trace (st/root-cause e) 15))))
+
+(comment
+  (load-ns 'yetibot.core.commands.help)
+  (load-ns 'i.will.fail)
+  )
 
 (defn find-and-load-namespaces
   "Find namespaces matching ns-patterns: a seq of regex patterns. Load the matching
    namespaces and return the seq of matched namespaces."
   [ns-patterns]
-  (let [nss (flatten (map find-namespaces ns-patterns))]
-    (info "☐ Loading" (count nss) "namespaces matching" ns-patterns)
-    (dorun (map load-ns nss))
-    (info "☑ Loaded" (count nss) "namespaces matching" ns-patterns)
+  (let [nss (flatten (map find-namespaces ns-patterns))
+        nss-count-output (str (count nss) " namespaces matching " ns-patterns)]
+    (info "☐ Loading" nss-count-output)
+    (doseq [n nss] (load-ns n))
+    (info "☑ Loaded" nss-count-output)
     nss))
+
+(comment
+  (find-and-load-namespaces '(#"yetibot\.core\.commands\.help"))
+  )
 
 (defn load-commands []
   (find-and-load-namespaces yetibot-command-namespaces))
+
+(comment
+  (load-commands)
+  )
 
 (defn load-observers []
   (find-and-load-namespaces yetibot-observer-namespaces))
@@ -98,6 +132,10 @@
                                   :repositories default-repositories)))
        plugins)
       (info "There are no plugins configured to load"))))
+
+(comment
+  (load-plugins)
+  )
 
 (defn load-all
   "Load all plugins, observers, and commands.

--- a/src/yetibot/core/loader.clj
+++ b/src/yetibot/core/loader.clj
@@ -65,7 +65,8 @@
    (first yetibot-observer-namespaces)))
 
 (def yetibot-all-namespaces
-  ;; to mimic previous use of merge, using `list` vs `vector` -- not sure if matters
+  ;; to mimic previous return type of (merge), using (list) vs plain old vector
+  ;; in theory, it should not matter (lazy vs non-lazy) -- but don't want to risk it
   (list all-command-plugins-regex
         all-observer-plugins-regex
         #"^yetibot\.(.(?!(core)))*"    ; with a negative lookahead assertion


### PR DESCRIPTION
- dropped non-used refs
- added some doc strings
- variablized regex related to "all" commands and observers
- used new regex vars to remove `(last)` logic in `(yetibot-all-namespaces)` << uncle bob would be proud
- small style changes in `(try)` << make kondo happy
- using `(doseq)` vs `(dorun)` for side effects << make codeclimate happy
- added comments and `(comment)`