### PR TITLE
mods to core/config.clj and added test for it

### DIFF
--- a/src/yetibot/core/util/config.clj
+++ b/src/yetibot/core/util/config.clj
@@ -47,6 +47,11 @@
       (error "Failed loading config: " e)
       nil)))
 
+(comment
+  (load-or-create-edn! "nope.edn")
+  (load-edn! "config/config.sample.edn")
+  )
+
 (defn get-config
   "Lookup configuration in a config tree.
    Returns one of:

--- a/test/yetibot/core/test/config.clj
+++ b/test/yetibot/core/test/config.clj
@@ -1,0 +1,36 @@
+(ns yetibot.core.test.config
+  (:require
+   [midje.sweet :refer [=> fact facts every-checker]]
+   [yetibot.core.config :as c]))
+
+(facts "about merge-possible-prefixes"
+       (let [merged-cfg (c/merge-possible-prefixes {:yetibot {:a 1}})]
+         (fact "returns a merged map of possible prefixes for
+                a file with valid prefixes"
+               merged-cfg => (every-checker map? not-empty)
+               (:a merged-cfg) => 1))
+       (let [merged-cfg (c/merge-possible-prefixes {:iwillfail {:a 1}})]
+         (fact "returns nil for a map with non-supported prefixes"
+               merged-cfg => nil)))
+
+(facts "about prefixed-env-vars"
+       (let [yb-env-vars (c/prefixed-env-vars {:yetibot-test true
+                                               :skip-me true})]
+         (fact "returns expected KV pair in non-empty map with
+                valid YB ENV vars"
+               yb-env-vars => (every-checker map? not-empty)
+               (:yetibot-test yb-env-vars) => true
+               (:skip-me yb-env-vars) => nil))
+       (let [yb-env-vars (c/prefixed-env-vars {:skip-me true})]
+         (fact "returns empty map when no valid YB ENV vars are present"
+               yb-env-vars => (every-checker map? empty?))))
+
+(facts "about config-from-env-or-file"
+       (let [yb-vars (c/config-from-env-or-file {:yetibot {:a 1}}
+                                                {:yetibot-b-c 2})]
+         (fact "returns expected KV items in non-empty map with
+                valid (user defined) YB file cfgs and env cfgs"
+               yb-vars => (every-checker map? not-empty)
+               (:a yb-vars) => 1
+               (:b yb-vars) => (every-checker map? not-empty)
+               (get-in yb-vars [:b :c]) => 2)))


### PR DESCRIPTION
- using idiomatic `if-not`
- added arity/1 to `prefixed-env-vars` to allow for user defined env vars, mainly for testing .. arity/0 (original func signature) passes in `environ.core/env` to arity/1
- added arity/1 and arity/2 to `config-from-env-or-file` to allow for user defined file cfgs and env cfgs .. arity/0 (original func signature) passes in `load-edn!` and `prefixed-env-vars` to arity/2 -- which were previously in the body of the function
- added many `(comment)`
- added test for core/config.clj

not sure how you are going to feel about me modifying the arity of those functions .. it won't hurt my feelings if you want to reject, i am just trying to find a "pure" way i can test these functions that don't rely on environmental factors ..
