### PR TITLE
extract generation of SQL query string from query map to allow for testing of generated statements

### DIFF
--- a/src/yetibot/core/db/util.clj
+++ b/src/yetibot/core/db/util.clj
@@ -186,7 +186,8 @@
   )
 
 (defn query
-  "Query with WHERE"
+  "SELECT query of table arg, allowing for complex WHERE clauses that contain
+   predicates and/or expressions, based on provided query-map arg."
   [table query-map]
   (let [sql-query (generate-sql-query table query-map)
         identifiers (:query/identifiers query-map)]

--- a/src/yetibot/core/db/util.clj
+++ b/src/yetibot/core/db/util.clj
@@ -142,20 +142,21 @@
   "Generates SQL query string based on table and query-map args.
    Allows us to seperate the generation of the SQL query and the
    execution of said query"
-  [table {;; provide either where/map
+  [table query-map]
+  (let [{;; provide either where/map
           ;;   or where/clause and where/args
           ;;   or both (they will be combined)
-          select-clause :select/clause
-          where-map :where/map
-          where-clause :where/clause
-          where-args :where/args
+         select-clause :select/clause
+         where-map :where/map
+         where-clause :where/clause
+         where-args :where/args
           ;; optional
-          group-clause :group/clause
-          having-clause :having/clause
-          order-clause :order/clause
-          offset-clause :offset/clause
-          limit-clause :limit/clause}]
-  (let [select-clause (or select-clause "*")
+         group-clause :group/clause
+         having-clause :having/clause
+         order-clause :order/clause
+         offset-clause :offset/clause
+         limit-clause :limit/clause} query-map
+        select-clause (or select-clause "*")
         [where-clause where-args] (combine-wheres
                                    (transform-where-map where-map)
                                    [where-clause where-args])]
@@ -189,15 +190,14 @@
   "SELECT query of table arg, allowing for complex WHERE clauses that contain
    predicates and/or expressions, based on provided query-map arg."
   [table query-map]
-  (let [sql-query (generate-sql-query table query-map)
-        identifiers (:query/identifiers query-map)]
+  (let [sql-query (generate-sql-query table query-map)]
     (info "db query" (color-str :blue (pr-str sql-query)))
     (seq
      (sql/with-db-connection
       [db-conn (:url (config))]
       (sql/query db-conn
                  sql-query
-                 {:identifiers (or identifiers kebab)})))))
+                 {:identifiers (or (:query/identifiers query-map) kebab)})))))
 
 (defn update-where
   [table where-map attrs]

--- a/src/yetibot/core/db/util.clj
+++ b/src/yetibot/core/db/util.clj
@@ -180,7 +180,7 @@
     :where/args [true]
     :group/clause "id"
     :having/clause "SUM(points) > 0"
-    :order-by "id"
+    :order/clause "id"
     :offset/clause 10
     :limit/clause 1})
   (generate-sql-query "hello" {:select/clause "COUNT(*) as count"})

--- a/test/yetibot/core/test/db/util.clj
+++ b/test/yetibot/core/test/db/util.clj
@@ -108,7 +108,7 @@
                                              :where/args [where-arg-bool]
                                              :group/clause "id"
                                              :having/clause "SUM(points) > 0"
-                                             :order-by "id"
+                                             :order/clause "id"
                                              :offset/clause 10
                                              :limit/clause 1})]
     sql-query => (every-checker
@@ -119,6 +119,7 @@
                   (contains "is_awesome=?")
                   (contains "GROUP BY id")
                   (contains "HAVING SUM(points) > 0")
+                  (contains "ORDER BY id")
                   (contains "OFFSET 10")
                   (contains "LIMIT 1"))
     arg1 => where-map-id


### PR DESCRIPTION
- pulled creation of SQL query string out of main `(query)` function
- generate SQL query string in new `(generate-sql-query)` function
- call new "generate" function from original "query" function
- inline get of `:query/identifiers`
- added `(comment)` to excercise code
- added tests for new `(generate-sql-query)` function, both simple and complex

i hope i am not being petty here .. i just like to be able to see/test the generated SQL before i actually use it .. i also get the generation of the SQL string is pretty simple, but there is real logic/transformation there that might be good to test

i decided to destructure in the `(let)` vs the function args so my editor is happy when viewing function docs
