### PR TITLE
small updates to models/(admin|help), added testing for models/admin, migrated testing for models/help to midje

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,8 +34,7 @@
   :main yetibot.core.init
   :plugins [[lein-environ "1.2.0"]
             [lein-inferv "20201028.232949.b461fd0"]
-            [lein-pprint "1.3.2"]
-            [lein-cljfmt "0.7.0"]]
+            [lein-pprint "1.3.2"]]
   :profiles {:profiles/dev {}
              :dev [:profiles/dev
                    {:plugins [[lein-midje "3.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,8 @@
   :main yetibot.core.init
   :plugins [[lein-environ "1.2.0"]
             [lein-inferv "20201028.232949.b461fd0"]
-            [lein-pprint "1.3.2"]]
+            [lein-pprint "1.3.2"]
+            [lein-cljfmt "0.7.0"]]
   :profiles {:profiles/dev {}
              :dev [:profiles/dev
                    {:plugins [[lein-midje "3.2.1"]

--- a/src/yetibot/core/models/admin.clj
+++ b/src/yetibot/core/models/admin.clj
@@ -12,8 +12,6 @@
 (defn config [] (get-config ::config [:admin]))
 
 (comment
-  ;; helps if you `source config/sample.env` to get
-  ;;   real values
   (config)
   )
 
@@ -44,5 +42,5 @@
 
 (comment
   (user-is-admin? {:id "U123123"})
-  (user-is-admin? {:id "fail"})
+  (user-is-admin? {:id "work"} {:value {:users ["work"]}})
   )

--- a/src/yetibot/core/models/admin.clj
+++ b/src/yetibot/core/models/admin.clj
@@ -17,11 +17,19 @@
   (config)
   )
 
-(defn admin-only-command? [cmd]
-  (boolean ((-> (config) :value :commands set) cmd)))
+(defn admin-only-command?
+  "See if cmd is in the list of admin commands as defined
+   by the instance 'config'. Arity/2 allows for passing in
+   custom config, mainly used for testing."
+  ([cmd] (admin-only-command? cmd (config)))
+  ([cmd cfg] (boolean
+              ((-> cfg :value :commands set) cmd))))
 
 (comment
   (admin-only-command? "obs")
+  (let [cfg {:value {:commands ["obs"]}}]
+    (println (admin-only-command? "obs" cfg))
+    (println (admin-only-command? "fail" cfg)))
   )
 
 (defn user-is-admin? [{:keys [id]}]

--- a/src/yetibot/core/models/admin.clj
+++ b/src/yetibot/core/models/admin.clj
@@ -20,10 +20,10 @@
 (defn admin-only-command?
   "See if cmd is in the list of admin commands as defined
    by the instance 'config'. Arity/2 allows for passing in
-   custom config, mainly used for testing."
+   custom config to compare against, mainly used for testing."
   ([cmd] (admin-only-command? cmd (config)))
-  ([cmd cfg] (boolean
-              ((-> cfg :value :commands set) cmd))))
+  ([cmd cfg-map] (boolean
+                  ((-> cfg-map :value :commands set) cmd))))
 
 (comment
   (admin-only-command? "obs")
@@ -32,9 +32,17 @@
     (println (admin-only-command? "fail" cfg)))
   )
 
-(defn user-is-admin? [{:keys [id]}]
-  (boolean ((-> (config) :value :users set) id)))
+(defn user-is-admin?
+  "See if user is in the list of admin users as defined
+   by the instance 'config'. Arity/2 allows for passing in
+   custom config to compare against, mainly used for testing."
+  ([user-map] (user-is-admin? user-map (config)))
+  ([user-map cfg-map]
+   (let [{:keys [id]} user-map]
+     (boolean
+      ((-> cfg-map :value :users set) id)))))
 
 (comment
   (user-is-admin? {:id "U123123"})
+  (user-is-admin? {:id "fail"})
   )

--- a/src/yetibot/core/models/admin.clj
+++ b/src/yetibot/core/models/admin.clj
@@ -11,8 +11,22 @@
 
 (defn config [] (get-config ::config [:admin]))
 
+(comment
+  ;; helps if you `source config/sample.env` to get
+  ;;   real values
+  (config)
+  )
+
 (defn admin-only-command? [cmd]
   (boolean ((-> (config) :value :commands set) cmd)))
 
+(comment
+  (admin-only-command? "obs")
+  )
+
 (defn user-is-admin? [{:keys [id]}]
   (boolean ((-> (config) :value :users set) id)))
+
+(comment
+  (user-is-admin? {:id "U123123"})
+  )

--- a/src/yetibot/core/models/help.clj
+++ b/src/yetibot/core/models/help.clj
@@ -52,8 +52,8 @@
 (defn get-alias-docs [] @alias-docs)
 
 (defn remove-docs
+  "Remove (alias-)docs from help store"
   [prefix]
-  ;; attemp to remove from both help stores
   (swap! alias-docs dissoc prefix)
   (swap! docs dissoc prefix))
 

--- a/src/yetibot/core/models/help.clj
+++ b/src/yetibot/core/models/help.clj
@@ -6,9 +6,7 @@
 
    Note: fuzzy matching only works on built in commands (not aliases)."
   (:require [clojure.string :as s]
-            [taoensso.timbre :refer [info warn error]]
-            [clj-fuzzy.metrics :refer [levenshtein]]
-            [clojure.data.json :as json]))
+            [clj-fuzzy.metrics :refer [levenshtein]]))
 
 (defonce ^{:doc "Map of prefix to corresponding command docs"}
   docs (atom {}))
@@ -84,7 +82,7 @@
      the same distance
    - return the list of topics with the same distance"
   [topic]
-  (when-let [[dist matches] (nearest-match-within-range topic)]
+  (when-let [[_ matches] (nearest-match-within-range topic)]
     (if (> (count matches) 1)
       ; multiple matches, suggest them to the user
       [(str "No matches for \"" topic "\". Did you mean: "

--- a/test/README.md
+++ b/test/README.md
@@ -43,15 +43,37 @@ Ran 35 tests containing 57 assertions.
 ### Testing Extra Credit
 
 #### Kondo-fy Code
+
 Using [`clj-kondo`](https://github.com/clj-kondo/clj-kondo), lint the modified code.
 ```bash
-clj-kondo --lint src/yetibot/core/db/util.clj
-clj-kondo --lint test/yetibot/core/test/db/util.clj
+$ clj-kondo --lint src/yetibot/core/db/util.clj
+$ clj-kondo --lint test/yetibot/core/test/db/util.clj
 ```
 
 #### Check for Climate Change
 
 Using [`codeclimate`](https://github.com/codeclimate/codeclimate), review the modified code.
 ```bash
-codeclimate analyze src/ test/
+$ codeclimate analyze src/ test/
+```
+
+### REPL Help
+
+#### Loading the Sample Config File
+
+Before you start the REPL (`lein repl`), if you are working in isolation (not connected to external systems besides the DB) and want to test reliances on project configs (i.e. admin commands/users, command prefixes/fallbacks, logging level/path, etc) - it's not a bad idea to load the sample environment config file and export its variables. For example:
+```bash
+# assumes you are in the project root directory
+$ source config/sample.env
+
+$ export $(cut -d= -f1 config/sample.env) &> /dev/null
+
+$ env | grep YETIBOT_ | sort
+YETIBOT_ADAPTERS_FREENODE_HOST=chat.freenode.net
+YETIBOT_ADAPTERS_FREENODE_PORT=7070
+YETIBOT_ADAPTERS_FREENODE_SSL=true
+YETIBOT_ADAPTERS_FREENODE_TYPE=irc
+...
+
+$ lein repl
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -61,12 +61,12 @@ $ codeclimate analyze src/ test/
 
 #### Loading the Sample Config File
 
-Before you start the REPL (`lein repl`), if you are working in isolation (not connected to external systems besides the DB) and want to test reliances on project configs (i.e. admin commands/users, command prefixes/fallbacks, logging level/path, etc) - it's not a bad idea to load the sample environment config file and export its variables. For example:
+Before you start the REPL (`lein repl`), if you are working in isolation (not connected to external systems, except maybe the DB) and want to test reliances on project configs (i.e. admin commands/users, command prefixes/fallbacks, logging level/path, etc) - it's not a bad idea to load the sample environment config file and export its variables. For example:
 ```bash
 # assumes you are in the project root directory
 $ source config/sample.env
 
-$ export $(cut -d= -f1 config/sample.env) &> /dev/null
+$ export $(cut -d "=" -f 1 config/sample.env | grep '^YETIBOT_')
 
 $ env | grep YETIBOT_ | sort
 YETIBOT_ADAPTERS_FREENODE_HOST=chat.freenode.net

--- a/test/yetibot/core/test/models/admin.clj
+++ b/test/yetibot/core/test/models/admin.clj
@@ -1,0 +1,13 @@
+(ns yetibot.core.test.models.admin
+  (:require [yetibot.core.models.admin :as a]
+            [midje.sweet :refer [=> fact facts]]))
+
+(facts
+ "about admin-only-command?"
+ (let [adm-cmds {:value {:commands ["yes"]}}]
+   (fact
+    "returns true for admin only command"
+    (a/admin-only-command? "yes" adm-cmds) => true)
+   (fact
+    "returns false for non-admin only command"
+    (a/admin-only-command? "no" adm-cmds) => false)))

--- a/test/yetibot/core/test/models/admin.clj
+++ b/test/yetibot/core/test/models/admin.clj
@@ -11,3 +11,13 @@
    (fact
     "returns false for non-admin only command"
     (a/admin-only-command? "no" adm-cmds) => false)))
+
+(facts
+ "about user-is-admin?"
+ (let [adm-users {:value {:users ["yes"]}}]
+   (fact
+    "returns true if user is in admin user list"
+    (a/user-is-admin? {:id "yes"} adm-users) => true)
+   (fact
+    "returns false if user is NOT in admin user list"
+    (a/user-is-admin? {:id "no"} adm-users) => false)))

--- a/test/yetibot/core/test/models/help.clj
+++ b/test/yetibot/core/test/models/help.clj
@@ -1,6 +1,5 @@
 (ns yetibot.core.test.models.help
   (:require [yetibot.core.models.help :as h]
-            [clojure.test :refer :all]
             [midje.sweet :refer [=> fact contains]]))
 
 (defn add-some-docs []

--- a/test/yetibot/core/test/models/help.clj
+++ b/test/yetibot/core/test/models/help.clj
@@ -1,14 +1,14 @@
 (ns yetibot.core.test.models.help
-  (:require
-    [yetibot.core.models.help :refer :all]
-    [clojure.test :refer :all]))
+  (:require [yetibot.core.models.help :as h]
+            [clojure.test :refer :all]
+            [midje.sweet :refer [=> fact contains]]))
 
 (defn add-some-docs []
-  (add-docs
+  (h/add-docs
     "grep"
     ["grep -A <foo> # do something"
      "grep -B <bar> # wow"])
-  (add-docs
+  (h/add-docs
     "git-commit"
     '("-a # all"
       "--amend # amend previous commit"
@@ -17,19 +17,17 @@
 
 (add-some-docs) ; setup
 
-(deftest add-and-retrieve-docs
-  (is
-    (not (empty? (get-docs-for "git-commit")))
-    "retrieve previously added docs for 'git commit'"))
+(fact "get-docs-for finds previously added docs for 'git commit'
+       and is not empty"
+      (h/get-docs-for "git-commit") => not-empty)
 
-(deftest test-fuzzy
-  (is
-    (re-find #"^grep" (first (fuzzy-get-docs-for "greo")))
-    "fuzzy match for greo should find grep"))
+(fact "fuzzy-get-docs-for should find the previously added docs
+       for 'grep' using 'greo' as input"
+      (first (h/fuzzy-get-docs-for "greo")) => (contains "grep"))
 
 (deftest similar
   (let [similar (map #(str "foobar" %) (range 4))]
-    (doall (map #(add-docs % ["foobar baz"]) similar))
+    (doall (map #(h/add-docs % ["foobar baz"]) similar))
     (is
-      (re-find #"Did.you.mean" (str (first (fuzzy-get-docs-for "foobar"))))
+      (re-find #"Did.you.mean" (str (first (h/fuzzy-get-docs-for "foobar"))))
       "When there are many similar matches, show them to the user")))

--- a/test/yetibot/core/test/models/help.clj
+++ b/test/yetibot/core/test/models/help.clj
@@ -4,15 +4,15 @@
 
 (defn add-some-docs []
   (h/add-docs
-    "grep"
-    ["grep -A <foo> # do something"
-     "grep -B <bar> # wow"])
+   "grep"
+   ["grep -A <foo> # do something"
+    "grep -B <bar> # wow"])
   (h/add-docs
-    "git-commit"
-    '("-a # all"
-      "--amend # amend previous commit"
-      "-m <msg>"
-      "--interactive"))
+   "git-commit"
+   '("-a # all"
+     "--amend # amend previous commit"
+     "-m <msg>"
+     "--interactive"))
   (let [similar (map #(str "foobar" %) (range 4))]
     (doseq [s similar] (h/add-docs s ["foobar baz"]))))
 

--- a/test/yetibot/core/test/models/help.clj
+++ b/test/yetibot/core/test/models/help.clj
@@ -13,7 +13,9 @@
     '("-a # all"
       "--amend # amend previous commit"
       "-m <msg>"
-      "--interactive")))
+      "--interactive"))
+  (let [similar (map #(str "foobar" %) (range 4))]
+    (doseq [s similar] (h/add-docs s ["foobar baz"]))))
 
 (add-some-docs) ; setup
 
@@ -25,9 +27,14 @@
        for 'grep' using 'greo' as input"
       (first (h/fuzzy-get-docs-for "greo")) => (contains "grep"))
 
-(deftest similar
-  (let [similar (map #(str "foobar" %) (range 4))]
-    (doall (map #(h/add-docs % ["foobar baz"]) similar))
-    (is
-      (re-find #"Did.you.mean" (str (first (h/fuzzy-get-docs-for "foobar"))))
-      "When there are many similar matches, show them to the user")))
+(fact "fuzzy-get-docs-for should prompt user with similar commands
+       when input command matches many similar items"
+      (first (h/fuzzy-get-docs-for "foobar")) => (contains "Did you mean"))
+
+(fact "remove-docs should remove a previously added doc
+       from the help store"
+      (h/add-docs "removeme" ["i am going to remove this soon"])
+      ;; prove it exists 1st
+      (h/get-docs-for "removeme") => not-empty
+      (h/remove-docs "removeme")
+      (h/get-docs-for "removeme") => empty?)


### PR DESCRIPTION
- added `(comment)` and doc strings to models/admin
- expanded to arity/2 for 2 functions in models/admin to allow for testing,, original function signatures (arity/1) passes in `(config)` to expanded arity/2
- destructuring in `(let)` for `(user-is-admin?)` arity/2 to make editor happy when retrieving doc string
- made kondo happy for models/help, as well as added doc string for `(remove-docs)`
- updated test/README for some REPL pointers when wanting to exercise code that relies on instance config
- added midje tests for models/admin
- migrated tests for models/help to midje, as well as adding one more

FYI -- i "fixed" and committed the tests with `lein cljfmt` -- to see what the result would be .. didn't want to assume "this is the way", so did not commit plugin to `project.clj` -- but thought i would share the result for reference
