### PR TITLE
re-org test code so NSs are being tested in the related test file

### DIFF
--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -1,16 +1,7 @@
 (ns yetibot.core.test.handler
   (:require
-   yetibot.core.commands.echo
-   yetibot.core.commands.help
-   yetibot.core.commands.category
-   yetibot.core.commands.collections
-   yetibot.core.commands.render
-
-   [midje.sweet :refer [fact facts =>]]
-   [yetibot.core.parser :refer [parse-and-eval parser]]
-   [yetibot.core.handler :refer :all]
-   [yetibot.core.commands.history]
-   [yetibot.core.util.command :refer [extract-command]]
+   [midje.sweet :refer [fact =>]]
+   [yetibot.core.handler :refer [handle-raw handle-unparsed-expr]]
    [clojure.string :as s]
    [yetibot.core.repl :refer [load-minimal]]))
 
@@ -31,58 +22,3 @@
 (fact
  "Newlines are preserved in command handling"
  (:value (handle-unparsed-expr (str "echo " multiline-str))) => multiline-str)
-
-(fact
- "Extracting commands allows specifying a prefix"
- (let [prefix "?"
-       body (str prefix "command arg1 arg2")]
-   (extract-command body prefix) => [body (subs body 1)]))
-
-(fact
- "Nothing is extracted from a potential command if the prefix does not match"
- (let [prefix "?"
-       body "|command arg1 arg2"]
-   (extract-command body prefix) => nil?))
-
-(fact
- "Commands can be piped in succession"
- (:value (parse-and-eval "echo there | echo `echo hi`")) =>
- "hi there")
-
-(fact
- "Commands with data work as expected"
- (:data (parse-and-eval "category names")) =>
- {:async "commands that execute asynchronously",
-  :broken
-  "known to be broken, probably due to an API that disappeared",
-  :chart "returns a chart of some kind",
-  :ci "continuous integration",
-  :collection "operates on collections",
-  :crude
-  "may return crude, racy and potentially NSFW results (e.g. urban)",
-  :fun "generally fun and not work-related",
-  :gif "returns a gif",
-  :img "returns an image url",
-  :info "information lookups (e.g. wiki, wolfram, weather)",
-  :infra "infrastructure automation",
-  :issue "issue tracker",
-  :meme "returns a meme",
-  :repl "language REPLs",
-  :util
-  "utilities that help transform expressions or operate Yetibot"})
-
-(facts
- "Sub expressions can access the data propagated from the previous pipe"
- ;;
- (:value (parse-and-eval
-          "category names | echo async: `render {{async}}`")) =>
- "async: commands that execute asynchronously"
- ;; slightly more compleex
- (:value
-  (parse-and-eval
-   "category names | echo async: `render {{async}}` ci: `render {{ci}}`")) =>
- "async: commands that execute asynchronously ci: continuous integration")
-
-(fact
- "Commands with literals can be transformed"
- (:value (parse-and-eval "echo \"hi\"")) => "\"hi\"")

--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -3,9 +3,7 @@
    [midje.sweet :refer [fact =>]]
    [yetibot.core.handler :refer [handle-raw handle-unparsed-expr]]
    [clojure.string :as s]
-   [yetibot.core.repl :refer [load-minimal]]))
-
-(load-minimal)
+   [yetibot.core.loader :as ldr]))
 
 (comment
   ;; generate some history
@@ -21,4 +19,5 @@
 
 (fact
  "Newlines are preserved in command handling"
+ (ldr/load-commands)
  (:value (handle-unparsed-expr (str "echo " multiline-str))) => multiline-str)

--- a/test/yetibot/core/test/util/command.clj
+++ b/test/yetibot/core/test/util/command.clj
@@ -3,7 +3,8 @@
    yetibot.core.commands.echo
    [midje.sweet :refer [fact facts => against-background]]
    [yetibot.core.util.command :refer [whitelist blacklist
-                                      embedded-cmds command-enabled?]]))
+                                      embedded-cmds command-enabled?
+                                      extract-command]]))
 
 (facts "About embedded commands"
        (fact "Embedded commands that aren't actually known commands are not parsed"
@@ -41,3 +42,14 @@
               (command-enabled? "echo") => true)
         (fact "list is enabled by default"
               (command-enabled? "list") => true)))
+
+(facts "about extract-command"
+       (fact "Extracting commands allows specifying a prefix"
+             (let [prefix "?"
+                   body (str prefix "command arg1 arg2")]
+               (extract-command body prefix) => [body (subs body 1)]))
+
+       (fact "Nothing is extracted from a potential command if the prefix does not match"
+             (let [prefix "?"
+                   body "|command arg1 arg2"]
+               (extract-command body prefix) => nil?)))


### PR DESCRIPTION
- moved tests around for `core/handler`, `core/parser`, and `core/util/command`
- some general cleanup
- made kondo happy

event tho local tests are working AOK, i expect initial GH test action to fail due to "race condition" concerning the loading of commands .. i believe this is because midje is either running tests in parallel and/or midje `facts` are ran in isolation << a little odd tho `lein test` runs locally without fail

will most likely require mod to each test file to include `core/loader/load-commands` .. will fix as needed
