### PR TITLE
small refactor of core/models/default-command and added tests for it

### DIFF
--- a/src/yetibot/core/models/default_command.clj
+++ b/src/yetibot/core/models/default_command.clj
@@ -40,7 +40,7 @@
                                      [:command :fallback :enabled])))
   ([cfg] (let [value (:value cfg)]
            (if-not (blank? value)
-             (not (= "false" value))
+             (not= "false" value)
              ;; enabled by default
              true))))
 

--- a/src/yetibot/core/models/default_command.clj
+++ b/src/yetibot/core/models/default_command.clj
@@ -1,35 +1,47 @@
 (ns yetibot.core.models.default-command
   "Determine which command to fallback to and whether fallback is enabled"
-  (:require
-    [clojure.string :refer [blank?]]
-    [clojure.spec.alpha :as s]
-    [yetibot.core.config :refer [get-config]]))
+  (:require [clojure.spec.alpha :as s]
+            [yetibot.core.config :refer [get-config]]))
 
 (s/def ::config any?)
 
-(defn configured-default-command []
-  (or
-    (:value (get-config ::config [:default :command]))
-    "help"))
+(defn configured-default-command
+  "Gets the default command, as defined by the instance config.
+   Arity/2 allows for passing in custom config to compare against,
+   mainly used for testing."
+  ([] (configured-default-command (get-config ::config
+                                              [:default :command])))
+  ([cfg] (or (:value cfg) "help")))
+
+(comment
+  (configured-default-command {:value "findme"})
+  (configured-default-command {})
+  )
 
 (s/def ::text string?)
 
 (defn fallback-help-text-override
-  "Optional config, may be nil"
-  []
-  (:value (get-config ::text [:command :fallback :help :text])))
+  "Optional config for fallback help text. May be nil. Arity/2 allows for passing
+   in custom config to compare against, mainly used for testing."
+  ([] (fallback-help-text-override (get-config ::text
+                                               [:command :fallback :help :text])))
+  ([cfg] (:value cfg)))
 
 (s/def ::fallback-commands-enabled-config string?)
 
 (defn fallback-enabled?
   "Determine whether fallback commands are enabled when user enters a command
    that doesn't exist. Default is true.
+   In the future this may be channel specific but for now it is global.
+   Arity/2 allows for passing in custom config to compare against, mainly used
+   for testing."
+  ([] (fallback-enabled? (get-config ::fallback-commands-enabled-config
+                                     [:command :fallback :enabled])))
+  ([cfg] (->> (:value cfg) str (= "false") not)))
 
-   In the future this may be channel specific but for now it is global."
-  []
-  (let [{value :value} (get-config ::fallback-commands-enabled-config
-                                   [:command :fallback :enabled])]
-    (if-not (blank? value)
-      (not (= "false" value))
-      ;; enabled by default
-      true)))
+(comment
+  (fallback-enabled? {:value "false"})
+  (fallback-enabled? {:value false})
+  (fallback-enabled? {:value "true"})
+  (fallback-enabled? {:value "thiswilldefaulttotrue"})
+  )

--- a/src/yetibot/core/models/default_command.clj
+++ b/src/yetibot/core/models/default_command.clj
@@ -1,7 +1,8 @@
 (ns yetibot.core.models.default-command
   "Determine which command to fallback to and whether fallback is enabled"
   (:require [clojure.spec.alpha :as s]
-            [yetibot.core.config :refer [get-config]]))
+            [yetibot.core.config :refer [get-config]]
+            [clojure.string :refer [blank?]]))
 
 (s/def ::config any?)
 
@@ -37,7 +38,11 @@
    for testing."
   ([] (fallback-enabled? (get-config ::fallback-commands-enabled-config
                                      [:command :fallback :enabled])))
-  ([cfg] (->> (:value cfg) str (= "false") not)))
+  ([cfg] (let [value (:value cfg)]
+           (if-not (blank? value)
+             (not (= "false" value))
+             ;; enabled by default
+             true))))
 
 (comment
   (fallback-enabled? {:value "false"})

--- a/src/yetibot/core/models/default_command.clj
+++ b/src/yetibot/core/models/default_command.clj
@@ -11,7 +11,7 @@
    mainly used for testing."
   ([] (configured-default-command (get-config ::config
                                               [:default :command])))
-  ([cfg] (or (:value cfg) "help")))
+  ([cfg] (get cfg :value "help")))
 
 (comment
   (configured-default-command {:value "findme"})

--- a/test/yetibot/core/test/models/default_command.clj
+++ b/test/yetibot/core/test/models/default_command.clj
@@ -1,0 +1,37 @@
+(ns yetibot.core.test.models.default-command
+  (:require [yetibot.core.models.default-command :as dc]
+            [midje.sweet :refer [=> fact facts]]))
+
+(facts
+ "about configured-default-command"
+ (fact
+  "returns a custom default command"
+  (dc/configured-default-command {:value "findme"}) => "findme")
+ (fact
+  "returns the help command if no default command is set"
+  (dc/configured-default-command {:error :not-found}) => "help"))
+
+(facts
+ "about fallback-help-text-override"
+ (fact
+  "returns a custom help text message"
+  (dc/fallback-help-text-override {:value "findme"}) => "findme")
+ (fact
+  "returns nil when no custom text message is found"
+  (dc/fallback-help-text-override {:error :not-found}) => nil))
+
+(facts
+ "about fallback-enabled?"
+ (fact
+  "returns true when 'true' is passed"
+  (dc/fallback-enabled? {:value "true"}) => true)
+ (fact
+  "returns true when some non string-ified boolen is passed"
+  (dc/fallback-enabled? {:value "thiswillalsobetrue"}) => true)
+ (fact
+  "returns true when an error is returned"
+  (dc/fallback-enabled? {:error :not-found}) => true)
+ (fact
+  "returns false when 'false' is passed"
+  (dc/fallback-enabled? {:value "false"}) => false
+  (dc/fallback-enabled? {:value false}) => false))

--- a/test/yetibot/core/test/models/default_command.clj
+++ b/test/yetibot/core/test/models/default_command.clj
@@ -1,6 +1,6 @@
 (ns yetibot.core.test.models.default-command
   (:require [yetibot.core.models.default-command :as dc]
-            [midje.sweet :refer [=> fact facts]]))
+            [midje.sweet :refer [=> fact facts throws]]))
 
 (facts
  "about configured-default-command"
@@ -23,20 +23,21 @@
 (facts
  "about fallback-enabled?"
  (fact
-  "returns true when 'true' is passed"
-  (dc/fallback-enabled? {:value "true"}) => true)
+  "returns true when 'true' is passed and Exception when true is passed"
+  (dc/fallback-enabled? {:value "true"}) => true
+  (dc/fallback-enabled? {:value true}) => (throws Exception))
  (fact
   "returns true when 'blank' is passed"
+  (dc/fallback-enabled? {:value nil}) => true
+  (dc/fallback-enabled? {:value ""}) => true
   (dc/fallback-enabled? {:value "   "}) => true)
  (fact
-  "returns true when some non string-ified boolen is passed"
+  "returns true when some string is passed that is not 'false'"
   (dc/fallback-enabled? {:value "thiswillalsobetrue"}) => true)
  (fact
   "returns true when an error is returned"
   (dc/fallback-enabled? {:error :not-found}) => true)
  (fact
-  "returns false when 'false' is passed"
+  "returns false when 'false' is passed and true when <Boolean>false is passed"
   (dc/fallback-enabled? {:value "false"}) => false
-  ;; this use to return true since comparison was between "false" and false
-  ;; mods stringify :value so comparison will now be be between "false" and "false"
-  (dc/fallback-enabled? {:value false}) => false))
+  (dc/fallback-enabled? {:value false}) => true))

--- a/test/yetibot/core/test/models/default_command.clj
+++ b/test/yetibot/core/test/models/default_command.clj
@@ -26,6 +26,9 @@
   "returns true when 'true' is passed"
   (dc/fallback-enabled? {:value "true"}) => true)
  (fact
+  "returns true when 'blank' is passed"
+  (dc/fallback-enabled? {:value "   "}) => true)
+ (fact
   "returns true when some non string-ified boolen is passed"
   (dc/fallback-enabled? {:value "thiswillalsobetrue"}) => true)
  (fact
@@ -34,4 +37,6 @@
  (fact
   "returns false when 'false' is passed"
   (dc/fallback-enabled? {:value "false"}) => false
+  ;; this use to return true since comparison was between "false" and false
+  ;; mods stringify :value so comparison will now be be between "false" and "false"
   (dc/fallback-enabled? {:value false}) => false))


### PR DESCRIPTION
- small mod to `(configured-default-command)` -- using `(get)` vs `(or)`, 98% sure it did not change behavior
- added/modified doc strings for some functions
- added arity/2 to some functions to allow for unit testing with custom configs
- original function signature remains, which does `(get-config)` and passes into arity/2
- added `(comment)` to exercise some code
- added midje tests
- made clj-kondo happy

a note about `(fallback-enabled?)` .. i didn't want to change the behavior of the function -- but it feels a bit "off", but nothing that has to be immediately changed .. let me explain ::
- `(= "false" "false") => true`
- `(= "false" false) => false` << that said, it would never make it that far because `(blank? false) => true`
- if `true` is passed into function, it blows up because `(blank? true)` throws runtime exception
- if `"true"` is passed into function, runtime is OK but obviously `(= "false" "true") => false`

finally, codeclimate is complaining about non-idiotmatic `(not (= "false" value))` .. using `(not=)` fixed it and passed all tests ..

all that said -- this PR is OK for what it is supposed to do -- add tests and small refactor wins where possible ..