### PR TITLE
small refactor of core/models/default-command and added tests for it

### DIFF
--- a/src/yetibot/core/models/default_command.clj
+++ b/src/yetibot/core/models/default_command.clj
@@ -7,15 +7,15 @@
 
 (s/def ::config any?)
 
-(defn configured-default-command []
-  (or
-    (:value (get-config ::config [:default :command]))
-    "help"))
+(defn configured-default-command
+  "Gets the default command, as defined by the instance config."
+  []
+  (get (get-config ::config [:default :command]) :value "help"))
 
 (s/def ::text string?)
 
 (defn fallback-help-text-override
-  "Optional config, may be nil"
+  "Optional config for fallback help text. May be nil."
   []
   (:value (get-config ::text [:command :fallback :help :text])))
 
@@ -30,6 +30,6 @@
   (let [{value :value} (get-config ::fallback-commands-enabled-config
                                    [:command :fallback :enabled])]
     (if-not (blank? value)
-      (not (= "false" value))
+      (not= "false" value)
       ;; enabled by default
       true)))

--- a/test/yetibot/core/test/models/default_command.clj
+++ b/test/yetibot/core/test/models/default_command.clj
@@ -1,0 +1,61 @@
+(ns yetibot.core.test.models.default-command
+  (:require [yetibot.core.models.default-command :as dc]
+            [yetibot.core.config :refer [get-config]]
+            [midje.sweet :refer [=> provided anything fact facts throws]]))
+
+(facts
+ "about configured-default-command"
+ (fact
+  "returns a custom default command"
+  (dc/configured-default-command) => "findme"
+  (provided (get-config anything [:default :command]) => {:value "findme"}))
+ (fact
+  "returns the help command if no default command is set"
+  (dc/configured-default-command) => "help"
+  (provided (get-config anything [:default :command]) => {:error :not-found})))
+
+(facts
+ "about fallback-help-text-override"
+ (fact
+  "returns a custom help text message"
+  (dc/fallback-help-text-override) => "findme"
+  (provided (get-config anything [:command :fallback :help :text]) => {:value "findme"}))
+ (fact
+  "returns nil when no custom text message is found"
+  (dc/fallback-help-text-override) => nil
+  (provided (get-config anything [:command :fallback :help :text]) => {:error :not-found})))
+
+(facts
+ "about fallback-enabled?"
+ (fact
+  "returns true when 'true' is passed"
+  (dc/fallback-enabled?) => true
+  (provided (get-config anything [:command :fallback :enabled]) => {:value "true"}))
+ (fact
+  "returns true when any string (not= 'false') is passed"
+  (dc/fallback-enabled?) => true
+  (provided (get-config anything [:command :fallback :enabled]) => {:value "somerandomstring"}))
+ (fact
+  "returns true when nil is passed"
+  (dc/fallback-enabled?) => true
+  (provided (get-config anything [:command :fallback :enabled]) => {:value nil}))
+ (fact
+  "returns true when blank is passed"
+  (dc/fallback-enabled?) => true
+  (provided (get-config anything [:command :fallback :enabled]) => {:value "   "}))
+ (fact
+  "returns true when <Boolean>false is passed"
+  (dc/fallback-enabled?) => true
+  (provided (get-config anything [:command :fallback :enabled]) => {:value false}))
+ (fact
+  "returns true when {:error anything} is passed"
+  (dc/fallback-enabled?) => true
+  (provided (get-config anything [:command :fallback :enabled]) => {:error :not-found}))
+ (fact
+  "throws exception when <Boolean> true is passed"
+  (dc/fallback-enabled?) => (throws Exception)
+  (provided (get-config anything [:command :fallback :enabled]) => {:value true}))
+ (fact
+  "returns false when 'false' is passed"
+  (dc/fallback-enabled?) => false
+  (provided (get-config anything [:command :fallback :enabled]) => {:value "false"})))


### PR DESCRIPTION
- small mod to `(configured-default-command)` -- using `(get)` vs `(or)`, 98% sure it did not change behavior
- added/modified doc strings for some functions
- added midje tests
- made clj-kondo happy
- made codeclimate happy by replacing `(not (=))` with `(not=)`

a note about `(fallback-enabled?)` .. i didn't want to change the behavior of the function -- but it feels a bit "off", but nothing that has to be immediately changed .. let me explain ::

- `(= "false" "false") => true`
- `(= "false" false) => false` << that said, it would never make it that far because `(blank? false) => true`
- if `true` is passed into function, it blows up because `(blank? true)` throws runtime exception
- if "true" is passed into function, runtime is OK but obviously `(= "false" "true") => false`

all that said -- this PR is OK for what it is supposed to do -- add tests and small refactor wins where possible ..

THANKS FOR THE HELP WITH MOCKS 🥳 
