### PR TITLE
improved linting, better test setup/teardown, re'org and added tests

### DIFF
--- a/src/yetibot/core/adapters/adapter.clj
+++ b/src/yetibot/core/adapters/adapter.clj
@@ -58,8 +58,8 @@
 
 (defn active-adapters
   "Get a list of active adapter values"
-  []
-  (vals @adapters))
+  ([] (active-adapters @adapters))
+  ([adapters] (vals adapters)))
 
 (defn web-adapter
   "Gets the config'ed web adapter"

--- a/src/yetibot/core/adapters/adapter.clj
+++ b/src/yetibot/core/adapters/adapter.clj
@@ -58,8 +58,8 @@
 
 (defn active-adapters
   "Get a list of active adapter values"
-  ([] (active-adapters @adapters))
-  ([adapters] (vals adapters)))
+  []
+  (vals @adapters))
 
 (defn web-adapter
   "Gets the config'ed web adapter"

--- a/src/yetibot/core/util/format.clj
+++ b/src/yetibot/core/util/format.clj
@@ -1,7 +1,6 @@
 (ns yetibot.core.util.format
   (:require
     [yetibot.core.util]
-    [taoensso.timbre :refer [info warn error]]
     [clojure.stacktrace :as st]
     [clojure.string :as s])
   (:import [clojure.lang Associative Sequential]))

--- a/test/yetibot/core/test/adapters.clj
+++ b/test/yetibot/core/test/adapters.clj
@@ -2,7 +2,8 @@
   (:require [yetibot.core.adapters :as a]
             [yetibot.core.adapters.adapter :as aa]
             [midje.sweet :refer [=> fact facts provided anything
-                                 every-checker contains just throws]]
+                                 every-checker contains just throws
+                                 with-state-changes before]]
             [yetibot.core.config :refer [get-config]]))
 
 (facts
@@ -49,12 +50,14 @@
 
 (facts
  "about stop"
- (fact
-  "stops and drops all active adapters"
-  ;; setup test adapter
-  (aa/register-adapter! "some-uuid" {:config {:type "web"}})
-  ;; do the thing and verify no more active adapters
-  (a/stop) => {}
-  (provided (run! anything anything) => {})
-  ;; double check what YB thinks is active after a stop
-  (aa/active-adapters) => nil))
+ (with-state-changes [(before :facts
+                              (aa/register-adapter! "some-uuid" {:config {:type "web"}}))]
+   (fact
+    "stops and drops all active adapters"
+    ;; prove the adapter exists
+    (aa/active-adapters) => '({:config {:type "web"}})
+    ;; stop all adapters
+    (a/stop) => {}
+    (provided (run! anything anything) => {})
+    ;; prove adapter no longers exists
+    (aa/active-adapters) => nil)))

--- a/test/yetibot/core/test/adapters/adapter.clj
+++ b/test/yetibot/core/test/adapters/adapter.clj
@@ -1,29 +1,33 @@
 (ns yetibot.core.test.adapters.adapter
   (:require [yetibot.core.adapters.adapter :as a]
-            [midje.sweet :refer [=> fact facts]]))
+            [midje.sweet :refer [=> fact facts with-state-changes after
+                                 provided]]))
 
 (facts
  "about register-adapter!"
- (fact
-  "registers a custom adapter and is perceived as active"
-  ;; verify it doesn't exist
-  (a/active-adapters) => nil
-  ;; do the thing
-  (a/register-adapter! "some-uuid" {:type "test"})
-  (a/active-adapters) => '({:type "test"})
-  ;; cleanup after myself
-  (reset! a/adapters {})
-  (a/active-adapters) => nil))
+ (with-state-changes [(after :facts
+                             (reset! a/adapters {}))]
+   (fact
+    "registers a custom adapter and is perceived as active"
+    ;; verify it doesn't exist
+    (a/active-adapters) => nil
+    ;; register an adapter
+    (a/register-adapter! "some-uuid" {:type "test"})
+    ;; verify adapter exists
+    (a/active-adapters) => '({:type "test"}))))
 
 (facts
  "about web-adapter"
  (fact
   "gets the web adapter from the list of registered adapters"
-  ;; verify it doesn't exist
-  (a/active-adapters) => nil
-  ;; do the thing
-  (a/register-adapter! "web-uuid" {:config {:type "web" :some "value"}})
   (a/web-adapter) => {:config {:type "web" :some "value"}}
-  ;; cleanup after myself
-  (reset! a/adapters {})
-  (a/active-adapters) => nil))
+  (provided (a/active-adapters) => '({:config {:type "web" :some "value"}}
+                                     {:config {:type "random" :some "other value"}}))))
+
+(facts
+ "about active adapters"
+ (fact
+  "gets the vals from the current list of adapters"
+  (a/active-adapters {:a1 {:a 1}
+                      :b2 {:b 2}}) => '({:a 1}
+                                        {:b 2})))

--- a/test/yetibot/core/test/adapters/adapter.clj
+++ b/test/yetibot/core/test/adapters/adapter.clj
@@ -23,11 +23,3 @@
   (a/web-adapter) => {:config {:type "web" :some "value"}}
   (provided (a/active-adapters) => '({:config {:type "web" :some "value"}}
                                      {:config {:type "random" :some "other value"}}))))
-
-(facts
- "about active adapters"
- (fact
-  "gets the vals from the current list of adapters"
-  (a/active-adapters {:a1 {:a 1}
-                      :b2 {:b 2}}) => '({:a 1}
-                                        {:b 2})))

--- a/test/yetibot/core/test/util/format.clj
+++ b/test/yetibot/core/test/util/format.clj
@@ -58,6 +58,11 @@
     (fmt/pseudo-format-n "foo --> $2 <-- two" [1 2]) =>
     "foo --> 2 <-- two")
    (fact
+    "will replace rebound prefix with empty string when defined arg
+     in list of args is outside list scope"
+    (fmt/pseudo-format-n "is --> $3 <-- empty" [1 2]) =>
+    "is -->  <-- empty")
+   (fact
     "shouldn't work with old prefix after new one is bound"
     (fmt/pseudo-format-n "--> %s <--" [1 2]) => "--> %s <-- 1 2")
    (fact
@@ -72,7 +77,10 @@
   (fmt/pseudo-format "foo" "bar") => "foo bar")
  (fact
   "substitutes middle param when given an arg"
-  (fmt/pseudo-format "foo %s baz" "bar") => "foo bar baz"))
+  (fmt/pseudo-format "foo %s baz" "bar") => "foo bar baz")
+ (fact
+  "substitutes mutliple %s params with given arg"
+  (fmt/pseudo-format "foo %s baz %s" "bar") => "foo bar baz bar"))
 
 (facts
  "about limit-and-trim-string-lines"

--- a/test/yetibot/core/test/util/format.clj
+++ b/test/yetibot/core/test/util/format.clj
@@ -106,3 +106,13 @@
   "does not remove mixed quotes"
   (fmt/remove-surrounding-quotes "\"no change'") =>
   "\"no change'"))
+
+(facts
+ "about to-coll-if-contains-newlines"
+ (fact
+  "returns coll if string contains new lines and keeps whitespace"
+  (fmt/to-coll-if-contains-newlines "1\n2\n  3") => ["1" "2" "  3"])
+ (fact
+  "returns arg when no new lines are present"
+  (fmt/to-coll-if-contains-newlines "123") => "123"
+  (fmt/to-coll-if-contains-newlines 123) => 123))

--- a/test/yetibot/core/test/util/format.clj
+++ b/test/yetibot/core/test/util/format.clj
@@ -11,41 +11,59 @@
    ["meme creator"
     "http://img-ipad.lisisoft.com/img/2/9/2974-1-meme-creator-pro-caption-memes.jpg"]])
 
-(def formatted-list (fmt/format-data-structure nested-list))
-
-(fact
- "the flattened representation should not contain collections"
- (let [[_ flattened] formatted-list]
-   flattened =not=> (contains coll?)))
-
-;; TODO port the rest of this to Midje
+(facts
+ "about format-data-structure"
+ (fact
+  "the flattened representation should not contain collections"
+  (let [[_ flattened] (fmt/format-data-structure nested-list)]
+    flattened =not=> (contains coll?))))
 
 (facts
- "format-n"
- (fmt/format-n "foo %1" [2]) => "foo 2"
- (fmt/format-n "foo" [2 3 4]) => "foo"
- (fmt/format-n "list %1 | head" [1]) => "list 1 | head")
+ "about format-n"
+ (fact
+  "will alter text with params using provided elements"
+  (fmt/format-n "foo %1" [2]) => "foo 2")
+ (fact
+  "will not alter text that has no params, but elements do exist"
+  (fmt/format-n "foo" [2 3 4]) => "foo")
+ (fact
+  "will alter complicated text with params using provided elements"
+  (fmt/format-n "list %1 | head" [1]) => "list 1 | head")
+ (fact
+  "will remove param from text if no supporting elements exist"
+  (fmt/format-n "skip %1" []) => "skip "))
 
 (facts
  "about pseudo-format-n"
  (let [args ["foo" "bar" "baz"]]
-   (fmt/pseudo-format-n
-    "all --> %s <-- there" args) => "all --> foo bar baz <-- there"
-   (fmt/pseudo-format-n "just the second --> %2 <--" args) =>
-   "just the second --> bar <--"
-   (fmt/pseudo-format-n "append to end -->" args) =>
-   "append to end --> foo bar baz")
- (fmt/pseudo-format-n "echo hi | echo bar" []) =>
- "echo hi | echo bar")
-
-(facts
- "about pseudo-format-n with rebound prefix"
+   (fact
+    "swaps out param with all args in list"
+    (fmt/pseudo-format-n "all --> %s <-- there" args) =>
+    "all --> foo bar baz <-- there")
+   (fact
+    "swaps out targeted param with defined item in list"
+    (fmt/pseudo-format-n "just the second --> %2 <--" args) =>
+    "just the second --> bar <--")
+   (fact
+    "will append to end of str the list of args if no params defined"
+    (fmt/pseudo-format-n "append to end -->" args) =>
+    "append to end --> foo bar baz"))
+ (fact
+  "does nothing when no params or args exist"
+  (fmt/pseudo-format-n "echo hi | echo bar" []) =>
+  "echo hi | echo bar")
  (binding [fmt/*subst-prefix* "\\$"]
-   ;; It should work with a new prefix.
-   (fmt/pseudo-format-n "foo --> $2 <-- two" [1 2]) =>
-   "foo --> 2 <-- two"
-   ;; It shouldn't work with the old prefix after a new one is bound.
-   (fmt/pseudo-format-n "--> %s <--" [1 2]) => "--> %s <-- 1 2"))
+   (fact
+    "will replace rebound prefix with defined arg in list of args"
+    (fmt/pseudo-format-n "foo --> $2 <-- two" [1 2]) =>
+    "foo --> 2 <-- two")
+   (fact
+    "shouldn't work with old prefix after new one is bound"
+    (fmt/pseudo-format-n "--> %s <--" [1 2]) => "--> %s <-- 1 2")
+   (fact
+    "should replace even if nothing to replace with"
+    (fmt/pseudo-format-n "qux --> $s <-- should b empty" []) =>
+    "qux -->  <-- should b empty")))
 
 (facts
  "Basic pseudo-format usage"
@@ -53,12 +71,6 @@
  (fact
   "It substitutes in the middle when it's supposed to")
  (fmt/pseudo-format "foo %s baz" "bar") => "foo bar baz")
-
-(facts
- "replace-even-if-nothing-to-replace-with"
- (binding [fmt/*subst-prefix* "\\$"]
-   (fmt/pseudo-format-n "qux --> $s <-- should b empty" []) =>
-   "qux -->  <-- should b empty"))
 
 (fact
  "limit-and-trim-string-lines-test"

--- a/test/yetibot/core/test/util/format.clj
+++ b/test/yetibot/core/test/util/format.clj
@@ -1,8 +1,7 @@
 (ns yetibot.core.test.util.format
   (:require
    [midje.sweet :refer [=> =not=> contains fact facts]]
-   [yetibot.core.util.format :refer :all]
-   [clojure.test :refer :all]))
+   [yetibot.core.util.format :as fmt]))
 
 (def nested-list
   [["meme generator"
@@ -12,54 +11,53 @@
    ["meme creator"
     "http://img-ipad.lisisoft.com/img/2/9/2974-1-meme-creator-pro-caption-memes.jpg"]])
 
-(def formatted-list (format-data-structure nested-list))
+(def formatted-list (fmt/format-data-structure nested-list))
 
 (fact
  "the flattened representation should not contain collections"
- (let [[formatted flattened] formatted-list]
+ (let [[_ flattened] formatted-list]
    flattened =not=> (contains coll?)))
 
 ;; TODO port the rest of this to Midje
 
 (facts
  "format-n"
- (format-n "foo %1" [2]) => "foo 2"
- (format-n "foo" [2 3 4]) => "foo"
- (format-n "list %1 | head" [1]) => "list 1 | head")
+ (fmt/format-n "foo %1" [2]) => "foo 2"
+ (fmt/format-n "foo" [2 3 4]) => "foo"
+ (fmt/format-n "list %1 | head" [1]) => "list 1 | head")
 
 (facts
- pseudo-format-n-test
+ "about pseudo-format-n"
  (let [args ["foo" "bar" "baz"]]
-   (pseudo-format-n
+   (fmt/pseudo-format-n
     "all --> %s <-- there" args) => "all --> foo bar baz <-- there"
-   (pseudo-format-n "just the second --> %2 <--" args) =>
+   (fmt/pseudo-format-n "just the second --> %2 <--" args) =>
    "just the second --> bar <--"
-   (pseudo-format-n "append to end -->" args) =>
+   (fmt/pseudo-format-n "append to end -->" args) =>
    "append to end --> foo bar baz")
- (pseudo-format-n "echo hi | echo bar" []) =>
+ (fmt/pseudo-format-n "echo hi | echo bar" []) =>
  "echo hi | echo bar")
 
 (facts
-  pseudo-format-n-with-rebound-prefix
-  (binding [*subst-prefix* "\\$"]
-    ;; It should work with a new prefix.
-    (pseudo-format-n "foo --> $2 <-- two" [1 2]) =>
-    "foo --> 2 <-- two"
-    ;; It shouldn't work with the old prefix after a new one is bound.
-    (pseudo-format-n "--> %s <--" [1 2])
-    "--> %s <-- 1 2"))
+ "about pseudo-format-n with rebound prefix"
+ (binding [fmt/*subst-prefix* "\\$"]
+   ;; It should work with a new prefix.
+   (fmt/pseudo-format-n "foo --> $2 <-- two" [1 2]) =>
+   "foo --> 2 <-- two"
+   ;; It shouldn't work with the old prefix after a new one is bound.
+   (fmt/pseudo-format-n "--> %s <--" [1 2]) => "--> %s <-- 1 2"))
 
 (facts
  "Basic pseudo-format usage"
- (pseudo-format "foo" "bar") => "foo bar"
+ (fmt/pseudo-format "foo" "bar") => "foo bar"
  (fact
   "It substitutes in the middle when it's supposed to")
- (pseudo-format "foo %s baz" "bar") => "foo bar baz")
+ (fmt/pseudo-format "foo %s baz" "bar") => "foo bar baz")
 
 (facts
  "replace-even-if-nothing-to-replace-with"
- (binding [*subst-prefix* "\\$"]
-   (pseudo-format-n "qux --> $s <-- should b empty" []) =>
+ (binding [fmt/*subst-prefix* "\\$"]
+   (fmt/pseudo-format-n "qux --> $s <-- should b empty" []) =>
    "qux -->  <-- should b empty"))
 
 (fact
@@ -71,14 +69,14 @@
            ok
            hi"
         expected "foo\nbar"]
-    (limit-and-trim-string-lines 2 s) => expected))
+    (fmt/limit-and-trim-string-lines 2 s) => expected))
 
 (facts
  "remove-surrounding-quotes"
  (fact
   "it removes surrounding double quotes"
-  (remove-surrounding-quotes "\"foo bar smack\"") => "foo bar smack")
+  (fmt/remove-surrounding-quotes "\"foo bar smack\"") => "foo bar smack")
  (fact
   "it removes surrounding single quotes"
-  (remove-surrounding-quotes "'bbq lolwat'") => "bbq lolwat"))
+  (fmt/remove-surrounding-quotes "'bbq lolwat'") => "bbq lolwat"))
 

--- a/test/yetibot/core/test/util/format.clj
+++ b/test/yetibot/core/test/util/format.clj
@@ -66,29 +66,43 @@
     "qux -->  <-- should b empty")))
 
 (facts
- "Basic pseudo-format usage"
- (fmt/pseudo-format "foo" "bar") => "foo bar"
+ "about pseudo-format"
  (fact
-  "It substitutes in the middle when it's supposed to")
- (fmt/pseudo-format "foo %s baz" "bar") => "foo bar baz")
-
-(fact
- "limit-and-trim-string-lines-test"
-  (let [s "foo
-           bar
-           baz
-           hi
-           ok
-           hi"
-        expected "foo\nbar"]
-    (fmt/limit-and-trim-string-lines 2 s) => expected))
+  "converts multiple args into string"
+  (fmt/pseudo-format "foo" "bar") => "foo bar")
+ (fact
+  "substitutes middle param when given an arg"
+  (fmt/pseudo-format "foo %s baz" "bar") => "foo bar baz"))
 
 (facts
- "remove-surrounding-quotes"
+ "about limit-and-trim-string-lines"
+ (let [s "foo
+          bar
+          baz
+          hi
+          ok
+          hi"]
+   (fact
+    "will take defined limit and trim strings (delim :newline) when
+     presented with many"
+    (fmt/limit-and-trim-string-lines 2 s) => "foo\nbar")
+   (fact
+    "will 1 string and return it with no delims"
+    (fmt/limit-and-trim-string-lines 1 s) => "foo")))
+
+(facts
+ "about remove-surrounding-quotes"
  (fact
   "it removes surrounding double quotes"
   (fmt/remove-surrounding-quotes "\"foo bar smack\"") => "foo bar smack")
  (fact
   "it removes surrounding single quotes"
-  (fmt/remove-surrounding-quotes "'bbq lolwat'") => "bbq lolwat"))
-
+  (fmt/remove-surrounding-quotes "'bbq lolwat'") => "bbq lolwat")
+ (fact
+  "does not remove inner quotes"
+  (fmt/remove-surrounding-quotes "this 'inner' quote") =>
+  "this 'inner' quote")
+ (fact
+  "does not remove mixed quotes"
+  (fmt/remove-surrounding-quotes "\"no change'") =>
+  "\"no change'"))


### PR DESCRIPTION
- removed all refs to `clojure.test` for tests in question
- simple kondo fixes for `src/yetibot/core/util/format.clj`
- better test setup for `test/yetibot/core/test/adapters.clj`
- better test teardown and mocking for `test/yetibot/core/test/adapters/adapter.clj`
- re'org and added tests for `test/yetibot/core/test/util/format.clj`

not the most meaningful PR -- but better use of and one step closer for the `midje` migration