### PR TITLE
migrate to midje for core.commands.alias

### DIFF
--- a/src/yetibot/core/commands/alias.clj
+++ b/src/yetibot/core/commands/alias.clj
@@ -1,12 +1,11 @@
 (ns yetibot.core.commands.alias
   (:require
     [clojure.set :refer [difference]]
-    [taoensso.timbre :refer [info warn error]]
+    [taoensso.timbre :refer [info]]
     [clojure.string :as s]
     [yetibot.core.util.format :refer [pseudo-format-n *subst-prefix*
                                       remove-surrounding-quotes]]
     [yetibot.core.handler :refer [record-and-run-raw]]
-    [yetibot.core.util.format :refer [format-n]]
     [yetibot.core.util.command :as command]
     [yetibot.core.models.help :as help]
     [yetibot.core.db.alias :as model]
@@ -62,7 +61,7 @@
   (let [new-alias-map {:user-id user-id :cmd-name cmd-name :cmd cmd}]
     (info "adding alias with" new-alias-map)
     (info "existing" (existing-alias cmd-name))
-    (if-let [{:keys [id] :as existing} (existing-alias cmd-name)]
+    (if-let [{id :id} (existing-alias cmd-name)]
       (model/update-where {:id id} new-alias-map)
       (model/create new-alias-map)))
   alias-info)

--- a/src/yetibot/core/commands/alias.clj
+++ b/src/yetibot/core/commands/alias.clj
@@ -68,7 +68,7 @@
 
 (defn load-aliases []
   (let [alias-cmds (model/find-all)]
-    (dorun (map wire-alias alias-cmds))))
+    (run! #(wire-alias %) alias-cmds)))
 
 (defn- built-in? [cmd]
   ;; subtract known aliases from every command registered in `help`

--- a/test/yetibot/core/test/commands/alias.clj
+++ b/test/yetibot/core/test/commands/alias.clj
@@ -1,15 +1,23 @@
 (ns yetibot.core.test.commands.alias
-  (:require
-    [clojure.test :refer :all]
-    [clojure.string :refer [split]]
-    [yetibot.core.commands.alias :refer :all]))
+  (:require [midje.sweet :refer [facts fact => provided]]
+            [yetibot.core.commands.alias :as alias]
+            [yetibot.core.db.alias :as model]))
 
-(let [args ["a = random \\| echo hi"
-            "b = echo hi"
-            "c = random \\| echo http://foo.com?bust=%s"]])
-
-(deftest alias-test
-  ; examples
-  "alias foo = echo %1"
-  "alias weatherzip = \"weather %1 | head %2 | tail\""
-  )
+(facts
+ "about add-alias"
+ (let [cmd-name "hello"
+       alias-info {:cmd-name cmd-name
+                   :cmd "echo hello"
+                   :user-id 123}
+       alias-id {:id 123}]
+   (fact
+    "will update an alias, with its ID, when the existing alias cmd name
+     already exists"
+    (alias/add-alias alias-info) => alias-info
+    (provided (#'alias/existing-alias cmd-name) => alias-id
+              (model/update-where alias-id alias-info) => nil))
+   (fact
+    "will create a new alias when the cmd name doesn't already exist"
+    (alias/add-alias alias-info) => alias-info
+    (provided (#'alias/existing-alias cmd-name) => nil
+              (model/create alias-info) => nil))))

--- a/test/yetibot/core/test/commands/alias.clj
+++ b/test/yetibot/core/test/commands/alias.clj
@@ -1,9 +1,11 @@
 (ns yetibot.core.test.commands.alias
-  (:require [midje.sweet :refer [facts fact => every-checker
-                                 provided contains]]
+  (:require [midje.sweet :refer [facts fact => every-checker against-background
+                                 provided contains truthy falsey]]
             [yetibot.core.commands.alias :as alias]
             [yetibot.core.db.alias :as model]
-            [yetibot.core.hooks :refer [cmd-unhook]]))
+            [yetibot.core.hooks :refer [cmd-unhook]]
+            [yetibot.core.models.help :as help]
+            [midje.util :refer [testable-privates]]))
 
 (facts
  "about add-alias"
@@ -54,3 +56,22 @@
     => (every-checker string?
                       (contains cmd))
     (provided (#'alias/existing-alias cmd) => nil))))
+
+(testable-privates yetibot.core.commands.alias cleaned-cmd-name)
+(facts
+ "about cleaned-cmd-name"
+ (fact
+  "returns 'cleaned' 1st element of command string args"
+  (cleaned-cmd-name "  hello world  ") => "hello"))
+
+(testable-privates yetibot.core.commands.alias built-in?)
+(facts
+ "about built-in? (all builtin commands w/ docs - all alias commands)"
+ (against-background (help/get-docs) => {"echo" {}}
+                     (model/find-all) => [{:cmd-name "alias1"}])
+ (fact
+  "returns the name of the command if considered a built-in"
+  (built-in? "echo") => truthy)
+ (fact
+  "returns nil if NOT considered a built-in"
+  (built-in? "alias1") => falsey))

--- a/test/yetibot/core/test/commands/alias.clj
+++ b/test/yetibot/core/test/commands/alias.clj
@@ -1,5 +1,6 @@
 (ns yetibot.core.test.commands.alias
-  (:require [midje.sweet :refer [facts fact => provided]]
+  (:require [midje.sweet :refer [facts fact =>
+                                 provided]]
             [yetibot.core.commands.alias :as alias]
             [yetibot.core.db.alias :as model]))
 
@@ -21,3 +22,15 @@
     (alias/add-alias alias-info) => alias-info
     (provided (#'alias/existing-alias cmd-name) => nil
               (model/create alias-info) => nil))))
+
+(facts
+ "about list-aliases"
+ (let [aliases [{:cmd-name "hello" :cmd "echo hello"}]]
+   (fact
+    "when aliases exist, returns result data and values, no errors"
+    (:result/data (alias/list-aliases :ignored)) => aliases
+    (provided (model/find-all) => aliases))
+   (fact
+    "when no aliases exist, returns result error with string"
+    (:result/error (alias/list-aliases :ignored)) => string?
+    (provided (model/find-all) => []))))


### PR DESCRIPTION
- `src/yetibot/core/commands/alias.clj`
  - small kondo cleanup changes by dropping refs and unused "vars"
  - made more idiomatic by using `(run!)` vs `(dorun (map))`
- `test/yetibot/core/test/commands/alias.clj`
  - migrated to midje
  - added new tests << including some privates

not curing cancer with this one -- but small move to having midje everywhere

i think codecov is going to yell at me because i made a change to src `(load-aliases)` without adding tests << is minor and hard to truly test because of side-effects