### PR TITLE
migrate tests to midje and small kondo cleanup

### DIFF
--- a/src/yetibot/core/commands/decode.clj
+++ b/src/yetibot/core/commands/decode.clj
@@ -1,9 +1,9 @@
 (ns yetibot.core.commands.decode
   (:require [yetibot.core.hooks :refer [cmd-hook]])
-  (:import org.apache.commons.lang3.StringEscapeUtils))
+  (:import (org.apache.commons.lang3 StringEscapeUtils)))
 
 (defn decode [s]
-  (org.apache.commons.lang3.StringEscapeUtils/unescapeHtml4 s))
+  (StringEscapeUtils/unescapeHtml4 s))
 
 (defn decode-cmd
   "decode <string> # decode HTML entities in <string> using StringEscapeUtils"

--- a/test/yetibot/core/test/commands/decode.clj
+++ b/test/yetibot/core/test/commands/decode.clj
@@ -1,11 +1,10 @@
 (ns yetibot.core.test.commands.decode
   (:require [yetibot.core.util.command-info :refer [command-execution-info]]
             [midje.sweet :refer [=> fact facts]]
-            [yetibot.core.loader :as ldr]))
+            yetibot.core.commands.decode))
 
 (facts
  "about decode"
- (ldr/load-commands)
  (fact
   "HTML encoded strings get decoded"
   (-> (command-execution-info

--- a/test/yetibot/core/test/commands/decode.clj
+++ b/test/yetibot/core/test/commands/decode.clj
@@ -1,17 +1,15 @@
 (ns yetibot.core.test.commands.decode
-  (:require
-    [yetibot.core.commands.decode :refer :all]
-    [yetibot.core.util.command-info :refer [command-execution-info]]
-    [clojure.test :refer :all]))
+  (:require [yetibot.core.util.command-info :refer [command-execution-info]]
+            [midje.sweet :refer [=> fact facts]]
+            [yetibot.core.loader :as ldr]))
 
-(def execution-opts {:run-command? true})
-
-(deftest decode-test
-  (testing "HTML encoded strings get decoded"
-    (is (= (-> (command-execution-info
-                 "decode Come check out Trevor Hartman&#39;s talk &quot;Growing a Chatops Platform and Having Fun with Clojure&quot; where we take a look at the development of Yetibot!"
-                 execution-opts)
-               :result
-               :result/value)
-           "Come check out Trevor Hartman's talk \"Growing a Chatops Platform and Having Fun with Clojure\" where we take a look at the development of Yetibot!"
-           ))))
+(facts
+ "about decode"
+ (ldr/load-commands)
+ (fact
+  "HTML encoded strings get decoded"
+  (-> (command-execution-info
+       "decode Come check out Trevor Hartman&#39;s talk &quot;Growing a Chatops Platform and Having Fun with Clojure&quot; where we take a look at the development of Yetibot!"
+       {:run-command? true})
+      :result
+      :result/value) => "Come check out Trevor Hartman's talk \"Growing a Chatops Platform and Having Fun with Clojure\" where we take a look at the development of Yetibot!"))


### PR DESCRIPTION
- `src/yetibot/core/commands/decode.clj`
  - a simple kondo quieting of a supposed "unused import"
- `test/yetibot/core/test/commands/decode.clj`
  - migration to midje only .. no new tests