### PR TITLE
migrate to midje for core.commands.observe and some kondo/codeclimate cleaning

### DIFF
--- a/src/yetibot/core/commands/observe.clj
+++ b/src/yetibot/core/commands/observe.clj
@@ -4,14 +4,13 @@
     [selmer.parser :refer [render]]
     [clojure.string :as s :refer [split trim]]
     [clojure.tools.cli :refer [parse-opts]]
-    [taoensso.timbre :refer [color-str debug trace info warn error]]
+    [taoensso.timbre :refer [color-str debug info]]
     [yetibot.core.chat :refer [*thread-ts* chat-data-structure]]
     [yetibot.core.db.observe :as model]
     [yetibot.core.handler :refer [record-and-run-raw all-event-types]]
     [yetibot.core.hooks :refer [cmd-hook obs-hook]]
     [yetibot.core.util.command :as command]
     [yetibot.core.interpreter :refer [*chat-source*]]
-    [yetibot.core.models.help :as help]
     [yetibot.core.util.format :refer [remove-surrounding-quotes]]))
 
 (def cli-options
@@ -186,9 +185,8 @@
       (let [{:keys [event-type user-pattern channel-pattern]}
             (:options parsed-opts)
 
-            pattern (if-let [args (->> parsed-opts :arguments seq)]
-                      (s/join " " args)
-                      nil)
+            pattern (when-let [args (->> parsed-opts :arguments seq)]
+                      (s/join " " args))
 
             obs-info (cond-> {:user-id (:username user)
                               :event-type event-type
@@ -227,7 +225,7 @@
       (format "Observer `%s` removed" id))))
 
 (defn load-observers []
-  (dorun (map wire-observer (model/find-all))))
+  (run! #(wire-observer %) (model/find-all)))
 
 (defonce loader (future (load-observers)))
 

--- a/test/yetibot/core/test/commands/observe.clj
+++ b/test/yetibot/core/test/commands/observe.clj
@@ -1,10 +1,23 @@
 (ns yetibot.core.test.commands.observe
-  (:require
-    [clojure.test :refer :all]
-    [clojure.string :refer [split]]
-    [yetibot.core.commands.observe :refer :all]))
+  (:require [midje.sweet :refer [=> facts fact contains]]
+            [yetibot.core.commands.observe :as obs]))
 
-(deftest observe-parse-test
-  (is (parse-observe-opts "-u lol x"))
-  (is (contains?  (parse-observe-opts "-u lol -ewat x") :errors )
-      "Should have errors with invalid event type"))
+(facts
+ "about commands.observe"
+ (fact
+  "it returns observed options that have no errors, contains the specified arg,
+   and recognizes the -u option with provided value"
+  (let [{:keys [arguments errors options]} (obs/parse-observe-opts
+                                            "-u lol x")]
+    errors => empty?
+    arguments => (contains "x")
+    (:user-pattern options) => "lol"))
+ (fact
+  "it will return an error when providing invalid options, but still will parse
+   whatever valid options it can find"
+  (let [{:keys [arguments errors options]} (obs/parse-observe-opts
+                                            "-u lol -ewat x")]
+    errors => coll?
+    (first errors) => (contains "Failed to validate")
+    arguments => (contains "x")
+    (:user-pattern options) => "lol")))

--- a/test/yetibot/core/test/commands/observe.clj
+++ b/test/yetibot/core/test/commands/observe.clj
@@ -5,7 +5,7 @@
 (facts
  "about commands.observe"
  (fact
-  "it returns observed options that have no errors, contains the specified arg,
+  "returns observed options that have no errors, contains the specified arg,
    and recognizes the -u option with provided value"
   (let [{:keys [arguments errors options]} (obs/parse-observe-opts
                                             "-u lol x")]
@@ -20,4 +20,26 @@
     errors => coll?
     (first errors) => (contains "Failed to validate")
     arguments => (contains "x")
-    (:user-pattern options) => "lol")))
+    (:user-pattern options) => "lol"))
+ (fact
+  "it will return a formatted observer of any pattern, no cmd, and no
+   event type when passed param with nothing"
+  (let [format (obs/format-observer {})]
+    format => "[any pattern]:  [event type: ] "))
+ (fact
+  "it will return a formatted observer with the pattern, cmd, and all
+   related map keys, wrapped in a '[<key>: <value>]' syntax; there are
+   some exceptions related to keys with '-' and (user-)id"
+  (let [format (obs/format-observer {:pattern "mypattern"
+                                     :cmd "mycmd"
+                                     :event-type "myeventtype"
+                                     :id "myid"
+                                     :user-pattern "myuserpattern"
+                                     :channel-pattern "mychannelpattern"
+                                     :user-id "myuserid"})]
+    format => (contains "mypattern: mycmd")
+    format => (contains "[event type: myeventtype]")
+    format => (contains "[id myid]")
+    format => (contains "[user pattern: myuserpattern]")
+    format => (contains "[channel pattern: mychannelpattern]")
+    format => (contains "[created by myuserid]"))))


### PR DESCRIPTION
- `src/yetibot/core/commands/observe.clj`
  - did some kondo cleaning
  - made changes to `(if-let)` to `(when-let)` because codeclimate said it is more idio than returning `nil` for logical false
  - made changes to `(dorun (map))` to `(run!)` because codeclimate said it is more idio

- `test/yetibot/core/test/commands/observe.clj`
  - migrated tests to midje and added one, non-amazing test