### PR TITLE
migrate to midje for core.models.history and some kondo/kibit cleaning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,8 @@
                    {:plugins [[lein-midje "3.2.1"]
                               [lambdaisland/kaocha-midje "0.0-5"
                                :exclusions [midje/midje]]
-                              [lein-cloverage "1.1.2"]]
+                              [lein-cloverage "1.1.2"]
+                              [lein-kibit "0.1.8"]]
                     :dependencies [[lilactown/punk-adapter-jvm "0.0.10"]
                                    [midje "1.9.9"]
                                    [nubank/matcher-combinators "1.2.4"]]}]

--- a/test/README.md
+++ b/test/README.md
@@ -66,6 +66,14 @@ Using [`cloverage`](https://github.com/cloverage/cloverage), check your code cov
 $ lein cloverage
 ```
 
+#### Check for Static
+
+Using [`kibit`](https://github.com/jonase/kibit), perform a static analysis of the modified code.
+```bash
+$ lein kibit src/yetibot/core/db/util.clj
+$ lein kibit test/yetibot/core/test/db/util.clj
+```
+
 #### Check for Climate Change
 
 Using [`codeclimate`](https://github.com/codeclimate/codeclimate), review the modified code.

--- a/test/yetibot/core/test/models/history.clj
+++ b/test/yetibot/core/test/models/history.clj
@@ -1,7 +1,6 @@
 (ns yetibot.core.test.models.history
   (:require [yetibot.core.models.history :as hst]
             [yetibot.core.db :as db]
-            [clojure.test :refer :all]
             [midje.sweet :refer [=> fact facts]]))
 
 (def chat-source {:adapter :slack :uuid :test :room "foo"})
@@ -12,48 +11,37 @@
 ;; we need a database
 (db/start)
 
-;; Another quick option would be to use a fixture to populate then rollback
-;; after the tests, something like:
-(defn populate
-  [f]
-  ;; this would require not using with-db-connection everywhere and having a
-  ;; reference to the db instead
-  ;; (sql/with-db-transaction [db db]
-  ;;   (sql/db-set-rollback-only! db)
-  ;;   (binding [db db]
-  ;;     ;; add 10 normal history items
-  ;;  (run! #(add-history (str "body" %)) (range 10))
-  ;;
-  ;;     ;; add 3 command history items
-  ;;  (run! add-history ["!echo" "!status" "!poke"])
-  (f))
-
-(use-fixtures :once populate)
-
 (def extra-query {:where/map {:chat-source-adapter (-> chat-source :uuid pr-str)
                               :is-yetibot false}})
 
-(deftest test-count-entities
-  (hst/count-entities extra-query))
-
-(deftest test-head
+(facts
+ "about core.models.history"
+ (fact
+  "it can count the number of entities without error"
+  (hst/count-entities extra-query) => int?)
+ (fact
+  "it can get the first lines of history without error"
   (hst/head 2 extra-query))
-
-(deftest test-tail
-  (count (hst/tail 2 extra-query)))
-
-(deftest test-random
-  (map? (hst/random extra-query)))
-
-(deftest test-grep
+ (fact
+  "it can get the last lines of history without error"
+  (hst/tail 2 extra-query))
+ (fact
+  "it can get history and show in random order without error"
+  (hst/random extra-query))
+ (fact
+  "it can search history for a specific pattern without error"
   (hst/grep "b.d+" extra-query))
-
-(deftest test-cmd-only-items
+ (fact
+  "it can get the history of commands only without error"
   (hst/cmd-only-items chat-source))
-
-(deftest test-non-cmd-items
+ (fact
+  "it can get the history of non-commands without error"
   (hst/non-cmd-items chat-source))
-
-(deftest last-chat-for-channel-test
-  (hst/last-chat-for-channel chat-source true)
-  (hst/last-chat-for-channel chat-source false))
+ (fact
+  "it can get the history of commands for a specific chat source without
+    error"
+  (hst/last-chat-for-channel chat-source true))
+ (fact
+  "it can get the history of 'normal chat' for a specific chat source
+    without error"
+  (hst/last-chat-for-channel chat-source false)))

--- a/test/yetibot/core/test/models/history.clj
+++ b/test/yetibot/core/test/models/history.clj
@@ -1,19 +1,10 @@
 (ns yetibot.core.test.models.history
-  (:require
-    [clojure.java.jdbc :as sql]
-    [yetibot.core.models.history :refer :all]
-    [yetibot.core.db :as db]
-    [yetibot.core.util.command :refer [command?]]
-    [clojure.test :refer :all]))
+  (:require [yetibot.core.models.history :as hst]
+            [yetibot.core.db :as db]
+            [clojure.test :refer :all]
+            [midje.sweet :refer [=> fact facts]]))
 
 (def chat-source {:adapter :slack :uuid :test :room "foo"})
-
-(defn add-history [body]
-  (add {:user-id "test"
-        :user-name "test"
-        :chat-source-adapter (:uuid chat-source)
-        :chat-source-room (:room chat-source)
-        :body body}))
 
 ;; TODO idempotent db create and teardown to keep test data out of the dev db
 ;; investigate embedded postgres as a solution:
@@ -43,30 +34,26 @@
                               :is-yetibot false}})
 
 (deftest test-count-entities
-  (count-entities extra-query))
+  (hst/count-entities extra-query))
 
 (deftest test-head
-  (head 2 extra-query))
+  (hst/head 2 extra-query))
 
 (deftest test-tail
-  (count (tail 2 extra-query)))
+  (count (hst/tail 2 extra-query)))
 
 (deftest test-random
-  (map? (random extra-query)))
+  (map? (hst/random extra-query)))
 
 (deftest test-grep
-  (grep "b.d+" extra-query))
+  (hst/grep "b.d+" extra-query))
 
 (deftest test-cmd-only-items
-  (cmd-only-items chat-source))
+  (hst/cmd-only-items chat-source))
 
 (deftest test-non-cmd-items
-  (non-cmd-items chat-source))
-
-(deftest history-should-be-in-order
-  ;; TODO
-  )
+  (hst/non-cmd-items chat-source))
 
 (deftest last-chat-for-channel-test
-  (last-chat-for-channel chat-source true)
-  (last-chat-for-channel chat-source false))
+  (hst/last-chat-for-channel chat-source true)
+  (hst/last-chat-for-channel chat-source false))


### PR DESCRIPTION
- `project.clj`
  - added kibit to plugins
- `src/yetibot/core/models/history.clj`
  - some kondo cleaning of unused refs and "vars"
  - small change to `(not=)` vs `(not (=))`
- `test/README.md`
  - update on how to use kibit locally
- `test/yetibot/core/test/models/history.clj`
  - migrate to midje
  - i think this is THE LAST of real use of clojure.test in core 🥳 🎈 👯 🕺 
  - ^^ minus one use of `(function?)` on a return type