### PR TITLE
small refactor of core.adapters.slack/send-msg

### DIFF
--- a/src/yetibot/core/adapters/slack.clj
+++ b/src/yetibot/core/adapters/slack.clj
@@ -119,26 +119,13 @@
   "defines options based on message and posts a message to slack, with some
     additional logging"
   [config msg]
-  (let [img? (image? msg)
-        _ (debug "send-msg"
-                 (color-str :blue
-                            {:img? img?
-                             :target *target*
-                             :thread-ts *thread-ts*}))
-
-        {:keys [ok] :as response}
-        (slack-chat/post-message
-          (slack-config config) *target* msg
-          (merge
-            {:unfurl_media (str (not (boolean img?))) :as_user "true"}
-            (when img?
-              {:blocks [{"type" "image"
-                         "image_url" msg
-                         "alt_text" "Image"}]})
-            (when *thread-ts* {:thread_ts *thread-ts*})))]
-    (if ok
-      (debug "slack response" (pr-str response))
-      (error "error posting to slack" (pr-str response)))))
+  (let [cfg (slack-config config)
+        opts (->send-msg-options msg)
+        resp (slack-chat/post-message cfg
+                                      *target*
+                                      msg
+                                      opts)]
+    (log-send-msg msg resp)))
 
 (defn send-paste [config msg]
   (slack-chat/post-message

--- a/src/yetibot/core/adapters/slack.clj
+++ b/src/yetibot/core/adapters/slack.clj
@@ -90,6 +90,31 @@
     (map :name (:groups (list-groups config)))
     (map #(str "#" (:name %)) (channels-in config))))
 
+(defn ->send-msg-options
+  "transform message to valid slack/post-message options, including thread
+   timestamp when available"
+  [msg]
+  (let [img? (image? msg)]
+    (merge
+     {:unfurl_media (str (not (boolean img?))) :as_user "true"}
+     (when img?
+       {:blocks [{"type" "image"
+                  "image_url" msg
+                  "alt_text" "Image"}]})
+     (when *thread-ts* {:thread_ts *thread-ts*}))))
+
+(defn log-send-msg
+  "log the send-msg message and slack's response"
+  [msg {:keys [ok] :as response}]
+  (let [img? (image? msg)
+        resp-str (pr-str response)]
+    (debug "send-msg" (color-str :blue {:img? img?
+                                        :target *target*
+                                        :thread-ts *thread-ts*}))
+    (if ok
+      (debug "slack response" resp-str)
+      (error "error posting to slack" resp-str))))
+
 (defn send-msg
   "defines options based on message and posts a message to slack, with some
     additional logging"

--- a/test/yetibot/core/test/adapters/slack.clj
+++ b/test/yetibot/core/test/adapters/slack.clj
@@ -131,12 +131,13 @@
  "about send-msg"
  (fact
   "it will attempt to post a message to slack using modified params and log it"
-  (slack/send-msg :config "hello world") => nil
-  (provided (slack-chat/post-message (slack/slack-config :config)
-                                     anything
-                                     "hello world"
-                                     anything)
-            => {:ok true}))
+  (let [msg "hello world"]
+    (slack/send-msg :config msg) => nil
+    (provided (slack-chat/post-message (slack/slack-config :config)
+                                       anything
+                                       msg
+                                       (slack/->send-msg-options msg))
+              => {:ok true})))
  (fact
   "it will attempt to post an image to slack using modified params and log it"
   (let [img "https://a.a/a.jpg"]
@@ -144,18 +145,19 @@
     (provided (slack-chat/post-message (slack/slack-config :config)
                                        anything
                                        img
-                                       anything)
+                                       (slack/->send-msg-options img))
               => {:ok false})))
  (fact
   "it will exercise the code that checks for a truthy *thread-ts* binding,
    and not throw an error"
-  (binding [yetibot.core.chat/*thread-ts* :threadts]
-    (slack/send-msg :config "hello world") => nil
-    (provided (slack-chat/post-message (slack/slack-config :config)
-                                       anything
-                                       "hello world"
-                                       anything)
-              => {:ok true}))))
+  (binding [yetibot.core.chat/*thread-ts* :ihaveathreadts]
+    (let [msg "hello world"]
+      (slack/send-msg :config msg) => nil
+      (provided (slack-chat/post-message (slack/slack-config :config)
+                                         anything
+                                         msg
+                                         (slack/->send-msg-options msg))
+                => {:ok true})))))
 
 (facts
  "about find-yetibot-user"

--- a/test/yetibot/core/test/adapters/slack.clj
+++ b/test/yetibot/core/test/adapters/slack.clj
@@ -454,3 +454,37 @@
               (reactions/add anything emoji {:channel channel
                                              :timestamp :somets})
               => :didreact))))
+
+(facts
+ "about ->send-msg-options"
+ (fact
+  "it will detect a non-image and unfurl"
+  (let [{:keys [unfurl_media]} (slack/->send-msg-options "helloworld")]
+    unfurl_media => "true"))
+ (fact
+  "it will detect an image URL and not unfurl it with a block image type"
+  (let [img "https://hello.com/world.jpg"
+        {:keys [unfurl_media]
+         [{:strs [type image_url alt_text]}] :blocks}
+        (slack/->send-msg-options img)]
+    unfurl_media => "false"
+    alt_text => "Image"
+    image_url => img
+    type => "image"))
+ (fact
+  "it return message options that include thread_ts data when binding for
+   *thread-ts* exists"
+  (binding [yetibot.core.chat/*thread-ts* :threadts]
+    (let [{:keys [unfurl_media thread_ts]} (slack/->send-msg-options
+                                            "helloworld")]
+      thread_ts => :threadts
+      unfurl_media => "true"))))
+
+(facts
+ "about log-send-msg"
+ (fact
+  "it logs debug when everything is AOK, always returning nil"
+  (slack/log-send-msg "https://a.a/a.jpg" {:ok true}) => nil)
+ (fact
+  "it logs error when everything is NOT AOK, always returning nil"
+  (slack/log-send-msg "hello world" {:ok false}) => nil))

--- a/test/yetibot/core/test/adapters/slack.clj
+++ b/test/yetibot/core/test/adapters/slack.clj
@@ -132,32 +132,35 @@
  (fact
   "it will attempt to post a message to slack using modified params and log it"
   (let [msg "hello world"]
-    (slack/send-msg :config msg) => nil
+    (slack/send-msg :config msg) => :didlog
     (provided (slack-chat/post-message (slack/slack-config :config)
                                        anything
                                        msg
                                        (slack/->send-msg-options msg))
-              => {:ok true})))
+              => {:ok true}
+              (slack/log-send-msg msg {:ok true}) => :didlog)))
  (fact
   "it will attempt to post an image to slack using modified params and log it"
   (let [img "https://a.a/a.jpg"]
-    (slack/send-msg :config img) => nil
+    (slack/send-msg :config img) => :didlog
     (provided (slack-chat/post-message (slack/slack-config :config)
                                        anything
                                        img
                                        (slack/->send-msg-options img))
-              => {:ok false})))
+              => {:ok false}
+              (slack/log-send-msg img {:ok false}) => :didlog)))
  (fact
   "it will exercise the code that checks for a truthy *thread-ts* binding,
    and not throw an error"
   (binding [yetibot.core.chat/*thread-ts* :ihaveathreadts]
     (let [msg "hello world"]
-      (slack/send-msg :config msg) => nil
+      (slack/send-msg :config msg) => :didlog
       (provided (slack-chat/post-message (slack/slack-config :config)
                                          anything
                                          msg
                                          (slack/->send-msg-options msg))
-                => {:ok true})))))
+                => {:ok true}
+                (slack/log-send-msg msg {:ok true}) => :didlog)))))
 
 (facts
  "about find-yetibot-user"


### PR DESCRIPTION
- `src/yetibot/core/adapters/slack.clj`
  - no change in behavior, function still returns `nil` since logging is the last action
  - extracted the send-msg options merge into own function
    - `->send-msg-options` naming comes from "elements of clojure" recommendation on how to name transforms
  - extracted logging of send-msg into own function
    - it appears both log actions are not dependent on ordering, so put into one
  - motivation comes from [LINK](https://kumarshantanu.medium.com/organizing-clojure-code-with-functional-core-imperative-shell-2f2ee869faa2)
    - `send-msg` becomes "workflow", while "core" is the creation of message options
- `test/yetibot/core/test/adapters/slack.clj`
  - you will see more meaningful tests for `send-msg`
  - new functions have their own tests

as always, very open to feedback, and feel free to reject .. just trying out some things i have been reading recently

take your time on this one and see if you like, because there any many opportunities like this throughout the code base
