### PR TITLE
refactor of adding user message to history table

### DIFF
--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -42,7 +42,7 @@
   (let [{value :value} (get-config ::embedded-commands-enabled-config
                                    [:command :embedded :enabled])]
     (if-not (blank? value)
-      (not (= "false" value))
+      (not= "false" value)
       ;; enabled by default
       true)))
 

--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -75,7 +75,7 @@
      :parsed-cmds parsed-cmds
      :cmd? cmd?}))
 
-(defn add-user-message-history
+(defn add-user-message-to-history
   "When the user is not Yetibot, it will add the user's messages to history"
   [body user correlation-id]
   (when (and user (not (:yetibot? user)))
@@ -136,7 +136,7 @@
         {:keys [parsed-normal-command parsed-cmds cmd?]}
         (->parsed-message-info body)]
     
-    (add-user-message-history body user correlation-id)
+    (add-user-message-to-history body user correlation-id)
 
     ;; When:
     ;; - the user's input was an expression (or contained embedded exprs)

--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -61,7 +61,7 @@
                   :parsed-normal-command nil}))))
 
 (facts
- "about add-user-message-history"
+ "about add-user-message-to-history"
  (let [body "!echo hello"
        user {:id 123 :username "greg" :yetibot? false}
        correlation-id (h/->correlation-id body user)
@@ -70,7 +70,7 @@
      (fact
       "it will add to the history table a user message, with related message
        metadata"
-      (first (h/add-user-message-history body user correlation-id))
+      (first (h/add-user-message-to-history body user correlation-id))
       => (contains {:body body
                     :chat_source_room (:room cs)
                     :correlation_id correlation-id
@@ -82,5 +82,5 @@
      (fact
       "it will NOT add the user message to history because user is yetibot,
        and return nil"
-      (h/add-user-message-history nil {:yetibot? true} nil)
+      (h/add-user-message-to-history nil {:yetibot? true} nil)
       => nil))))

--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -1,14 +1,15 @@
 (ns yetibot.core.test.handler
   (:require
-   [midje.sweet :refer [fact =>]]
-   [yetibot.core.handler :refer [handle-raw handle-unparsed-expr]]
+   [midje.sweet :refer [facts fact => =not=> contains]]
+   [yetibot.core.handler :as h]
    [clojure.string :as s]
-   [yetibot.core.loader :as ldr]))
+   [yetibot.core.interpreter :as i]
+   [yetibot.core.commands.echo]))
 
 (comment
   ;; generate some history
   (dotimes [i 10]
-    (handle-raw
+    (h/handle-raw
      {:adapter :test :room "foo"}
      {:id "yetitest"}
      :message
@@ -19,5 +20,67 @@
 
 (fact
  "Newlines are preserved in command handling"
- (ldr/load-commands)
- (:value (handle-unparsed-expr (str "echo " multiline-str))) => multiline-str)
+ ;;  (ldr/load-commands)
+ (:value (h/handle-unparsed-expr (str "echo " multiline-str))) => multiline-str)
+
+(facts
+ "about ->correlation-id"
+ (binding [i/*chat-source* {:adapter :slack
+                            :uuid :test
+                            :room "#C123"}]
+   (let [user {:id 123 :username "greg" :yetibot? false}]
+     (fact
+      "it will return an id of numbers and hyphens"
+      (h/->correlation-id "!echo hello" user) => #"[0-9]+[-]+[0-9]+")
+
+     (let [inst1 (h/->correlation-id "!echo hello" user)
+           _ (Thread/sleep 1000)
+           inst2 (h/->correlation-id "!echo hello" user)]
+       (fact
+        "the id is unique, even when the user and message body are the same
+         because it incorporates a timestamp"
+        inst1 =not=> inst2)))))
+
+(facts
+ "about ->parsed-message-info"
+ (binding [i/*chat-source* {:adapter :slack
+                            :uuid :test
+                            :room "#C123"}]
+   (fact
+    "it recognizes a command and has command related info"
+    (h/->parsed-message-info "!echo hello")
+    => (contains {:cmd? true
+                  :parsed-cmds coll?
+                  :parsed-normal-command coll?}))
+
+   (fact
+    "it recognizes a non-command and has non-command related info"
+    (h/->parsed-message-info "i am not a command")
+    => (contains {:cmd? false
+                  :parsed-cmds empty? ; is an empty list
+                  :parsed-normal-command nil}))))
+
+(facts
+ "about add-user-message-history"
+ (let [body "!echo hello"
+       user {:id 123 :username "greg" :yetibot? false}
+       correlation-id (h/->correlation-id body user)
+       cs {:adapter :slack :uuid :test :room "#C123"}]
+   (binding [i/*chat-source* cs]
+     (fact
+      "it will add to the history table a user message, with related message
+       metadata"
+      (first (h/add-user-message-history body user correlation-id))
+      => (contains {:body body
+                    :chat_source_room (:room cs)
+                    :correlation_id correlation-id
+                    :is_command true
+                    :is_yetibot false
+                    :user_id (str (:id user))
+                    :user_name (:username user)}))
+
+     (fact
+      "it will NOT add the user message to history because user is yetibot,
+       and return nil"
+      (h/add-user-message-history nil {:yetibot? true} nil)
+      => nil))))


### PR DESCRIPTION
- `src/yetibot/core/handler.clj`
  - kondo clean unused refs and bindings
  - extracted creation of correlation id `(->correlation-id)` into its own function and added tests
  - extracted the "parsing" of the message body `(->parsed-message-info)` into its own function and added tests
  - extracted the adding of a user's message to history `(add-user-message-to-history)` into its own function and added tests
  - used newly extracted functions to create let bindings
  - used newly extracted function to add user message to history
  - verified at DB level history is being added as expected (see below)
  - kibit change to use `(not=)` vs `(not (=))`
- `test/yetibot/core/test/handler.clj`
  - kondo clean unused refs and bindings
  - added tests for newly created functions

*SIDE NOTE:* this is step 1 of refactoring to `(record-and-run-raw)` function where newly extracted functions can be re-used -- didn't want to overwhelm tho, so breaking it up


```
yetibot=# \pset format csv
Output format is csv.

yetibot=# SELECT body, correlation_id FROM yetibot_history;
body,correlation_id
!help,1625587679182-1496177164
"Use `help <command>` on any of the following for more details.
Use `category` to list command by their category,  e.g. `category list fun`.
✅ Fallback commands are enabled, and the default command is `help`. This is triggered when a user enters a command that does not exist, and passes whatever the user entered as args to the fallback command.

Available commands:

`!`, `about`, `alias`, `category`, `channel`, `cmd`, `count`, `cron`, `data`, `date`, `decode`, `default`, `droplast`, `duckling`, `echo`, `error`, `eval`, `flatten`, `grep`, `head`, `help`, `history`, `join`, `karma`, `keys`, `letters`, `list`, `my`, `nil`, `obs`, `observer`, `our`, `parse`, `random`, `range`, `raw`, `react`, `render`, `repeat`, `replyto`, `rest`, `reverse`, `set`, `shuffle`, `sort`, `sortnum`, `split`, `ssh`, `status`, `sum`, `tail`, `take`, `tee`, `test`, `that`, `trim`, `unletters`, `unquote`, `unwords`, `uptime`, `url`, `users`, `vals`, `words`, `xargs`, `yeti`",1625587679182-1496177164

!echo hello,1625587687483--455860553
hello,1625587687483--455860553

!this is not a command,1625588132325-748017754
"help all # get help for all topics
help <topic> # get help for <topic>. If no exact matches are found for topic, it will fallback to the topic with the smallest Levenshtein distance < 2",1625588132325-748017754
```
