### PR TITLE
refactor of adding bot response to history table

### DIFF
--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -100,6 +100,45 @@
             interp/*chat-source* chat-source]
     (transformer parse-tree)))
 
+(defn ->handled-expr-info
+  "Helper to transform a handled user expression (command) and return and info
+   map about the handled command, such as if errored, the result, formatted
+   response, and the original command string"
+  [{:keys [value error] :as _handle-parsed-expr} parse-tree]
+  (let [original-command-str (unparse parse-tree)
+        result (or value error)
+        error? (not (nil? error))
+        [formatted-response _] (format-data-structure
+                                result)]
+    {:original-command-str original-command-str
+     :result result
+     :error? error?
+     :formatted-response formatted-response}))
+
+(defn add-bot-response-to-history
+  "When `record-yetibot-response?` is true, it will add the bot's
+   response to history table, before/during posting it back to
+   the chat adapter. Then we can more easily correlate request (e.g. commands
+   from user) and response (output from Yetibot)"
+  [{:keys [original-command-str formatted-response error?]
+    :as _handled-expr-info}
+   yetibot-user record-yetibot-response? correlation-id]
+  (let [{:keys [room uuid is-private]} interp/*chat-source*]
+    (trace record-yetibot-response? "recording history" uuid room is-private
+           original-command-str formatted-response)
+    (when record-yetibot-response?
+      (h/add {:chat-source-adapter uuid
+              :chat-source-room room
+              :is-private is-private
+              :correlation-id correlation-id
+              :user-id (-> yetibot-user :id str)
+              :user-name (-> yetibot-user :username str)
+              :is-yetibot true
+              :is-command false
+              :is-error error?
+              :command original-command-str
+              :body formatted-response}))))
+
 (defn record-and-run-raw
   "Top level message handler.
 
@@ -131,11 +170,10 @@
                               :or {record-yetibot-response? true}}]]
   (trace "record-and-run-raw" body record-yetibot-response?
         interp/*chat-source*)
-  (let [{:keys [room uuid is-private] :as chat-source} interp/*chat-source*
-        correlation-id (->correlation-id body user)
+  (let [correlation-id (->correlation-id body user)
         {:keys [parsed-normal-command parsed-cmds cmd?]}
         (->parsed-message-info body)]
-    
+
     (add-user-message-to-history body user correlation-id)
 
     ;; When:
@@ -148,51 +186,34 @@
     (when (and cmd? (not (:yetibot? user)))
       (let [[results _timeout-result]
             (alts!!
-              [(go (map
-                     (fn [parse-tree]
-                       (try
-                         (let [original-command-str (unparse parse-tree)
-                               {:keys [value error]} (handle-parsed-expr
-                                                       chat-source user
-                                                       yetibot-user
-                                                       parse-tree)
-                               result (or value error)
-                               error? (not (nil? error))
-                               [formatted-response _] (format-data-structure
-                                                        result)]
-                           ;; Yetibot should record its own response in
-                           ;; `history` table before/during posting it back to
-                           ;; the chat adapter. Then we can more easily
-                           ;; correlate request (e.g. commands from user) and
-                           ;; response (output from Yetibot)
-                           (trace
-                             record-yetibot-response?
-                             "recording history" uuid room is-private
-                                 original-command-str formatted-response)
-                           (when record-yetibot-response?
-                             (h/add {:chat-source-adapter uuid
-                                     :chat-source-room room
-                                     :is-private is-private
-                                     :correlation-id correlation-id
-                                     :user-id (-> yetibot-user :id str)
-                                     :user-name (-> yetibot-user :username str)
-                                     :is-yetibot true
-                                     :is-command false
-                                     :is-error error?
-                                     :command original-command-str
-                                     :body formatted-response}))
-                           ;; don't report errors on embedded commands
-                           {:embedded? (not parsed-normal-command)
-                            :error? error?
-                            :result result})
-                         (catch Throwable ex
-                           (error "error handling expression:" body
-                                  (format-exception-log ex))
-                           {:embedded?  (not parsed-normal-command)
-                            :error? true
-                            :result (format exception-format ex)})))
-                     parsed-cmds))
-               (timeout expr-eval-timeout-ms)])]
+             [(go (map
+                   (fn [parse-tree]
+                     (try
+                       (let [{:keys [result error?] :as handled-expr-info}
+                             (->handled-expr-info (handle-parsed-expr
+                                                   interp/*chat-source*
+                                                   user
+                                                   yetibot-user
+                                                   parse-tree)
+                                                  parse-tree)]
+                         
+                         (add-bot-response-to-history handled-expr-info
+                                                      yetibot-user
+                                                      record-yetibot-response?
+                                                      correlation-id)
+
+                         ;; don't report errors on embedded commands
+                         {:embedded? (not parsed-normal-command)
+                          :error? error?
+                          :result result})
+                       (catch Throwable ex
+                         (error "error handling expression:" body
+                                (format-exception-log ex))
+                         {:embedded?  (not parsed-normal-command)
+                          :error? true
+                          :result (format exception-format ex)})))
+                   parsed-cmds))
+              (timeout expr-eval-timeout-ms)])]
         (or results
             [{:timeout? true
               :result (str "Evaluation of `" body "` timed out after "

--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -1,10 +1,11 @@
 (ns yetibot.core.test.handler
   (:require
-   [midje.sweet :refer [facts fact => =not=> contains]]
+   [midje.sweet :refer [facts fact => =not=> contains provided]]
    [yetibot.core.handler :as h]
    [clojure.string :as s]
    [yetibot.core.interpreter :as i]
-   [yetibot.core.commands.echo]))
+   [yetibot.core.commands.echo]
+   [yetibot.core.chat :refer [chat-data-structure]]))
 
 (comment
   ;; generate some history
@@ -172,3 +173,31 @@
                                             false
                                             correlation-id))
       => nil))))
+
+(facts
+ "about ->handled-expr-results"
+ (fact
+  "it will return a collection that signifies a timeout was reached during
+   the processing of a message, when the results arg is not truthy"
+  (:timeout? (first (h/->handled-expr-results nil nil))) => true)
+ 
+ (fact
+  "it will return the results when the results arg evaluates to something
+   truthy"
+  (h/->handled-expr-results nil true) => true))
+
+(facts
+ "about dispatch-command-response"
+ (fact
+  "it will take a valid and successful result and pass it to be formatted
+   and send to chat adapter"
+  (h/dispatch-command-response {:embedded? false
+                                :error? false
+                                :result :myresult}) => :didsend
+  (provided (chat-data-structure :myresult) => :didsend))
+ 
+ (fact
+  "it will take a non-successful command response, log it, and return nil"
+  (h/dispatch-command-response {:embedded? true
+                                :error? true
+                                :result :myresult}) => nil))


### PR DESCRIPTION
- `src/yetibot/core/handler.clj`
  - extracted into `(->handled-expr-info)` logic transforming handled expr result into useful info map to be used by other functions
  - extracted into `(add-bot-response-to-history)` logic recording bot response to history table when option is enabled
  - extracted into `(->handled-expr-results)` logic transforming handled expr results into useful collection to be returned by function
  - modified `(record-and-run-raw)` to use new functions and kondo-cleaned where recommended
  - extracted into `(dispatch-command-response)` logic dispatching response to be formatted, and ultimately passed long to `send-message`
  - modified `(handle-raw)` to use new functions
- `test/yetibot/core/test/handler.clj`
  - created tests for newly extracted functions

verified at DB level history is being added as expected when issuing bot commands (see below)

![image](https://user-images.githubusercontent.com/2514988/124819952-e2236600-df3a-11eb-8183-43ca262f4d7c.png)

```
yetibot=# \pset format csv
Output format is csv.

yetibot=# SELECT body, correlation_id FROM yetibot_history;
body,correlation_id
!echo hello,1625686226960--1704927648
hello,1625686226960--1704927648

!echo hello | echo world,1625686238105--752889806
world hello,1625686238105--752889806

!history,1625686317249-1915014611
"greg in greg at 12:30 PM 07/07: !echo hello
myeti in greg at 12:30 PM 07/07: hello
greg in greg at 12:30 PM 07/07: !echo hello | echo world
myeti in greg at 12:30 PM 07/07: world hello",1625686317249-1915014611
```