### PR TITLE
for YB.core.adapters, small change to src and added test

### DIFF
--- a/src/yetibot/core/adapters.clj
+++ b/src/yetibot/core/adapters.clj
@@ -50,7 +50,7 @@
 (defn ->registerable-adapter
   [uuid adapter-config]
   (let [adapter-config (assoc adapter-config :name uuid)]
-    (debug "Making registerable" (pr-str adapter-config))
+    (debug "transform to registerable adapter" (pr-str adapter-config))
     (make-adapter adapter-config)))
 
 (defn register-adapters!

--- a/src/yetibot/core/adapters.clj
+++ b/src/yetibot/core/adapters.clj
@@ -47,14 +47,18 @@
     :mattermost (mattermost/make-mattermost config)
     (throw (ex-info (str "Unknown adapter type " (:type config)) config))))
 
+(defn ->registerable-adapter
+  [uuid adapter-config]
+  (let [adapter-config (assoc adapter-config :name uuid)]
+    (debug "Making registerable" (pr-str adapter-config))
+    (make-adapter adapter-config)))
+
 (defn register-adapters!
   "Registers all config'ed adapters"
   []
   (run!
    (fn [[uuid adapter-config]]
-     (let [adapter-config (assoc adapter-config :name uuid)]
-       (debug "Registering" (pr-str adapter-config))
-       (a/register-adapter! uuid (make-adapter adapter-config))))
+     (a/register-adapter! uuid (->registerable-adapter uuid adapter-config)))
    (adapters-config)))
 
 (defn start-adapters!


### PR DESCRIPTION
- `src/yetibot/core/adapters.clj`
  - added transform function `(->registerable-adapter)` for related logic
  - updated `(register-adapters!)` to use new transform

- `test/yetibot/core/test/adapters.clj`
  - simply added some more tests, nothing earth shattering
