### PR TITLE
refactoring `(record-and-run-raw)` with tests

### DIFF
--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -228,8 +228,8 @@
                               :or {record-yetibot-response? true}}]]
   (trace
    "record-and-run-raw" body record-yetibot-response? interp/*chat-source*)
-  (let [cmd-param-map (->cmd-param-map user
-                                       body
+  (let [cmd-param-map (->cmd-param-map body
+                                       user
                                        yetibot-user
                                        record-yetibot-response?)]
     (add-user-message-to-history cmd-param-map)

--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -165,14 +165,14 @@
      :non-yetibot-cmd (and cmd? (not (:yetibot? user)))
      :embedded? (not parsed-normal-command)}))
 
-(defn ->successfull-handled-expr
+(defn ->successfully-handled-expr
   [{:keys [error? result] :as _handled-expr-info}
    {:keys [embedded?] :as _cmd-param-map}]
   {:embedded? embedded?
    :error? error?
    :result result})
 
-(defn ->unsuccessfull-handled-expr
+(defn ->unsuccessfully-handled-expr
   [{:keys [body embedded?] :as _cmd-param-map}
    ex]
   (error "error handling expression:" body (format-exception-log ex))
@@ -192,10 +192,10 @@
       (add-bot-response-to-history handled-expr-info
                                    cmd-param-map)
 
-      (->successfull-handled-expr handled-expr-info
+      (->successfully-handled-expr handled-expr-info
                                   cmd-param-map))
     (catch Throwable ex
-      (->unsuccessfull-handled-expr cmd-param-map ex))))
+      (->unsuccessfully-handled-expr cmd-param-map ex))))
 
 (defn record-and-run-raw
   "Top level message handler.

--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -193,7 +193,7 @@
                                    cmd-param-map)
 
       (->successfully-handled-expr handled-expr-info
-                                  cmd-param-map))
+                                   cmd-param-map))
     (catch Throwable ex
       (->unsuccessfully-handled-expr cmd-param-map ex))))
 

--- a/src/yetibot/core/handler.clj
+++ b/src/yetibot/core/handler.clj
@@ -146,6 +146,24 @@
         :result (str "Evaluation of `" body "` timed out after "
                      (/ expr-eval-timeout-ms 1000) " seconds.")}]))
 
+(defn ->cmd-param-map
+  "returns a parameter map related to the handling of a command"
+  [body user yetibot-user record-yetibot-response?]
+  (let [{:keys [parsed-normal-command parsed-cmds cmd?]}
+        (->parsed-message-info body)]
+    {:body body
+     :user user
+     :yetibot-user yetibot-user
+     :record-yetibot-response? record-yetibot-response?
+     :correlation-id (->correlation-id body user)
+     :parsed-normal-command parsed-normal-command
+     :parsed-cmds parsed-cmds
+     :cmd? cmd?
+     ;; the user's input was an expression (or contained embedded exprs)
+     ;; and the user is not Yetibot
+     :non-yetibot-cmd (and cmd? (not (:yetibot? user)))
+     :embedded? (not parsed-normal-command)}))
+
 (defn record-and-run-raw
   "Top level message handler.
 

--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -65,44 +65,49 @@
  "about add-user-message-to-history"
  (let [body "!echo hello"
        user {:id 123 :username "greg" :yetibot? false}
-       correlation-id (h/->correlation-id body user)
+       cmd-param-map (h/->cmd-param-map body
+                                        user
+                                        nil
+                                        nil)
+       yb-cmd-param-map (h/->cmd-param-map body
+                                           (assoc user
+                                                  :yetibot?
+                                                  true)
+                                           nil
+                                           nil)
        cs {:adapter :slack :uuid :test :room "#C123"}]
    (binding [i/*chat-source* cs]
      (fact
       "it will add to the history table a user message, with related message
        metadata"
-      (first (h/add-user-message-to-history body user correlation-id))
+      (first (h/add-user-message-to-history cmd-param-map))
       => (contains {:body body
                     :chat_source_room (:room cs)
-                    :correlation_id correlation-id
+                    :correlation_id (:correlation-id cmd-param-map)
                     :is_command true
                     :is_yetibot false
                     :user_id (str (:id user))
                     :user_name (:username user)}))
-
+     
      (fact
       "it will NOT add the user message to history because user is yetibot,
        and return nil"
-      (h/add-user-message-to-history nil {:yetibot? true} nil)
+      (h/add-user-message-to-history yb-cmd-param-map)
       => nil))))
 
 (facts
  "about handle-parsed-expr"
- (let [cs {:adapter :slack
-           :uuid :test
-           :room "#C123"}
-       user {:id 123 :username "greg" :yetibot? false}
-       yb-user {:id 456 :username "yetibot" :yetibot? true}]
+ (let [user {:id 123 :username "greg" :yetibot? false}
+       yb-user {:id 456 :username "yetibot" :yetibot? true}
+       cmd-param-map {:user user :yetibot-user yb-user}]
    (fact
     "it will return nil when no legit parse tree is passed in as an arg"
-    (h/handle-parsed-expr cs user yb-user nil) => nil)
+    (h/handle-parsed-expr cmd-param-map nil) => nil)
 
    (fact
     "it will return a map with the value of the response, related data,
      and settings"
-    (h/handle-parsed-expr cs
-                          user
-                          yb-user
+    (h/handle-parsed-expr cmd-param-map
                           (first
                            (:parsed-cmds (h/->parsed-message-info
                                           "!echo hello"))))
@@ -112,17 +117,13 @@
 
 (facts
  "about ->handled-expr-info"
- (let [cs {:adapter :slack
-           :uuid :test
-           :room "#C123"}
-       user {:id 123 :username "greg" :yetibot? false}
+ (let [user {:id 123 :username "greg" :yetibot? false}
        yb-user {:id 456 :username "yetibot" :yetibot? true}
+       cmd-param-map {:user user :yetibot-user yb-user}
        pe (first
            (:parsed-cmds (h/->parsed-message-info
                           "!echo hello")))
-       hpe (h/handle-parsed-expr cs
-                                 user
-                                 yb-user
+       hpe (h/handle-parsed-expr cmd-param-map
                                  pe)]
    (fact
     "it transforms a successfully handled parsed expression (command) and
@@ -139,26 +140,20 @@
  (let [body "!echo hello"
        user {:id 123 :username "greg" :yetibot? false}
        yb-user {:id 456 :username "yetibot" :yetibot? true}
-       correlation-id (h/->correlation-id body user)
+       cmd-param-map (h/->cmd-param-map body user yb-user true)
        cs {:adapter :slack :uuid :test :room "#C123"}
        pe (first
-           (:parsed-cmds (h/->parsed-message-info
-                          "!echo hello")))
-       hpe (h/handle-parsed-expr cs
-                                 user
-                                 yb-user
-                                 pe)]
+           (:parsed-cmds cmd-param-map))
+       hpe (h/handle-parsed-expr cmd-param-map pe)]
    (binding [i/*chat-source* cs]
      (fact
       "it will take the parsed YB bot response from a command and add
        it to the history database with the defined correlation id"
       (first (h/add-bot-response-to-history (h/->handled-expr-info hpe pe)
-                                            yb-user
-                                            true
-                                            correlation-id))
+                                            cmd-param-map))
       => (contains {:body "hello"
                     :chat_source_room (:room cs)
-                    :correlation_id correlation-id
+                    :correlation_id (:correlation-id cmd-param-map)
                     :is_command false
                     :is_yetibot true
                     :is_error false
@@ -169,9 +164,9 @@
       "it will NOT add the bot response to history because the
        `record-yetibot-response?` option is not true"
       (first (h/add-bot-response-to-history (h/->handled-expr-info hpe pe)
-                                            yb-user
-                                            false
-                                            correlation-id))
+                                            (assoc cmd-param-map
+                                                   :record-yetibot-response?
+                                                   false)))
       => nil))))
 
 (facts


### PR DESCRIPTION
- `src/yetibot/core/handler.clj`
  - created "parameter object" function `(->cmd-param-map)` related to the `(record-and-run-raw)` function
  - using new param object in `(add-user-message-to-history)`
  - using new param object in `(handle-parsed-expr)`, also removed redundant binding of `interp/*chat-source`
  - using new param object in `(add-bot-response-to-history)`
  - extracted successfully handled expr result into own function `(->successfully-handled-expr)`
  - extracted unsuccessful handled expr (exception) result into own function `(->unsuccessfully-handled-expr)`
  - extracted logic surrounding the evaluation of an expression and the recording of its response into own function `(eval-expr-and-record-response)`
  - modified `(record-and-run-raw)` to use newly extracted functions and param object

- `test/yetibot/core/test/handler.clj`
  - adjusted tests to use new param object
  - added new tests for newly extracted functions
  - added tests for existing functions that could benefit from them

- ran tests using new install and verified commands are being evaluated and recorded
```
# psql -d yetibot -U yetibot -W
Password:
psql (13.3 (Debian 13.3-1.pgdg100+1))

yetibot=# \pset format csv
Output format is csv.

yetibot=# SELECT body, correlation_id FROM yetibot_history;
body,correlation_id

!echo hello,1628079174632--945183739
hello,1628079174632--945183739

!echo hello | echo world,1628079188014-263791484
world hello,1628079188014-263791484

!history,1628079193910-1894664892
"greg in greg at 05:12 AM 08/04: !echo hello
myeti in greg at 05:12 AM 08/04: hello
greg in greg at 05:13 AM 08/04: !echo hello | echo world
myeti in greg at 05:13 AM 08/04: world hello",1628079193910-1894664892
```

![image](https://user-images.githubusercontent.com/2514988/128181040-1f19cf0a-7171-4163-a48b-572bef94ad20.png)
