### PR TITLE
added tests for YB.core.chat and fixed syntax for tests related to YB.core.parser

### DIFF
--- a/test/yetibot/core/test/parser.clj
+++ b/test/yetibot/core/test/parser.clj
@@ -1,6 +1,6 @@
 (ns yetibot.core.test.parser
   (:require [midje.sweet :refer [=> fact facts]]
-            [yetibot.core.unparser :refer [unparse]
+            [yetibot.core.unparser :refer [unparse]]
             [yetibot.core.parser :refer [parser parse-and-eval]]))
 
 (facts "single commands should be parsed"


### PR DESCRIPTION
- `test/yetibot/core/test/chat.clj`
  - nothing earth-shattering, just thought i would increase test coverage
  - required some london school (interaction testing) to get things to working just enough to return a useable/testable result

- `test/yetibot/core/test/parser.clj`
  - noticed there was a syntax error in the tests for YB.core.parser -- so i fixed it
  - i guess midje is "smart enough" to just ignore these kinds of errors rather than throw an exception