### PR TITLE
removed unused function, added tests for util.format

### DIFF
--- a/src/yetibot/core/util/format.clj
+++ b/src/yetibot/core/util/format.clj
@@ -98,10 +98,6 @@
     (let [ds (if (set? d) (seq d) d)]
       [(format-flattened ds) ds])))
 
-(defn format-data-as-string [d]
-  (let [[s _] (format-data-structure d)]
-    s))
-
 (defn to-coll-if-contains-newlines
   "Convert a String to a List if the string contains newlines. Bit of a hack but
    it lets us get out of explicitly supporting streams in every command that we

--- a/test/yetibot/core/test/util/format.clj
+++ b/test/yetibot/core/test/util/format.clj
@@ -16,7 +16,34 @@
  (fact
   "the flattened representation should not contain collections"
   (let [[_ flattened] (fmt/format-data-structure nested-list)]
-    flattened =not=> (contains coll?))))
+    flattened =not=> (contains coll?)))
+ 
+ (fact
+  "it will stringify the contents of the collection and return a tuple that
+   contains said stringification as the 1st element and the actual collection as
+   the second value
+   
+   NOTE: when the 1st element of a non-map collection is a map, it drops that 1st
+   element and performs the creation of the tuple on the rest of the collection
+   values"
+  (fmt/format-data-structure {:hello :world})
+  => ["hello: :world" {:hello :world}]
+
+  (fmt/format-data-structure {:hello :world :how :ru})
+  => ["hello: :world\nhow: :ru" {:hello :world :how :ru}]
+
+  (fmt/format-data-structure [:hello :world :how :ru])
+  => [":hello\n:world\n:how\n:ru" [:hello :world :how :ru]]
+
+  (fmt/format-data-structure {{:hello :world} :howru :ihope :well})
+  => ["{:hello :world}: :howru\nihope: :well" {:ihope :well {:hello :world} :howru}]
+
+  (fmt/format-data-structure #{1 {:hello :world}})
+  => ["1\n{:hello :world}" '(1 {:hello :world})]
+
+  ;; this is what the NOTE is about .. on purpose ??
+  (fmt/format-data-structure [{:hello :world} {:how :ru}])
+  => ["how: :ru" {:how :ru}]))
 
 (facts
  "about format-n"
@@ -124,3 +151,10 @@
   "returns arg when no new lines are present"
   (fmt/to-coll-if-contains-newlines "123") => "123"
   (fmt/to-coll-if-contains-newlines 123) => 123))
+
+(facts
+ "about format-exception-log"
+ (fact
+  "it will .."
+  (fmt/format-exception-log (Exception. "hello world"))
+  => #"(?is)Exception.+hello world.+format\.clj"))


### PR DESCRIPTION
- `src/yetibot/core/util/format.clj`
  - dropped function `format-data-as-string`
  - check both YB and core and didn't see any reference to it -- so think it is safe

- `test/yetibot/core/test/util/format.clj`
  - added some additional tests for YB.core.util.format
  - nothing earth shattering, just thought i tease out the `format-data-structure` function to see what it would do in various conditions
  - also added test for `format-exception-log`

!! IT'S 🍟 DAY !!