### PR TITLE
loading of db schema and required commands for test NS

### DIFF
--- a/test/yetibot/core/test/db.clj
+++ b/test/yetibot/core/test/db.clj
@@ -1,0 +1,5 @@
+(ns yetibot.core.test.db
+  (:require
+   [yetibot.core.db :as db]))
+
+(defonce loader (db/start))

--- a/test/yetibot/core/test/parser.clj
+++ b/test/yetibot/core/test/parser.clj
@@ -1,7 +1,9 @@
 (ns yetibot.core.test.parser
   (:require [midje.sweet :refer [=> fact facts]]
             [yetibot.core.unparser :refer [unparse]]
-            [yetibot.core.parser :refer [parser parse-and-eval]]))
+            [yetibot.core.parser :refer [parser parse-and-eval]]
+            yetibot.core.test.db
+            [yetibot.core.loader :refer [load-ns]]))
 
 (facts "single commands should be parsed"
   (parser "uptime") => [:expr [:cmd [:words "uptime"]]]
@@ -226,11 +228,13 @@
  "about parse-and-eval"
  (fact
   "Commands can be piped in succession"
+  (load-ns 'yetibot.core.commands.echo)
   (:value (parse-and-eval "echo there | echo `echo hi`")) =>
   "hi there")
 
  (fact
   "Commands with data work as expected"
+  (load-ns 'yetibot.core.commands.category)
   (:data (parse-and-eval "category names")) =>
   {:async "commands that execute asynchronously"
    :broken
@@ -254,6 +258,9 @@
  (fact
   "Sub expressions can access the data propagated from the previous pipe"
  ;;
+  (load-ns 'yetibot.core.commands.category)
+  (load-ns 'yetibot.core.commands.echo)
+  (load-ns 'yetibot.core.commands.render)
   (:value (parse-and-eval
            "category names | echo async: `render {{async}}`")) =>
   "async: commands that execute asynchronously"
@@ -265,4 +272,5 @@
 
  (fact
   "Commands with literals can be transformed"
+  (load-ns 'yetibot.core.commands.echo)
   (:value (parse-and-eval "echo \"hi\"")) => "\"hi\""))


### PR DESCRIPTION
oh-kay, here's the situation (<< name that tune)

i want to work on and test a specific NS, and only that NS .. when running tests for the 1st time in a clean environment (`docker-compose up -d` 1st run, no data, no previous runs of test), i get fails when ONLY testing that NS .. example ::

```bash
lein test yetibot.core.test.parser
...
...
22-04-20 19:40:03 GKS-MBP.local INFO [yetibot.core.interpreter:160] - reduce commands ([:cmd [:words "category" [:space " "] "names"]] [:cmd [:words "echo" [:space " "] "async:" [:space " "] [:sub-expr [:expr [:cmd [:words "render" [:space " "] "{{async}}"]]]]]])

22-04-20 19:40:03 GKS-MBP.local INFO [yetibot.core.db.util:194] - db query ["SELECT * FROM yetibot_channel WHERE chat_source_adapter=? AND chat_source_channel=?" "nil" nil]

FAIL about parse-and-eval - Sub expressions can access the data propagated from the previous pipe at (parser.clj:257)
Expected:
"async: commands that execute asynchronously"
Actual:
org.postgresql.util.PSQLException: ERROR: relation "yetibot_channel" does not exist
  Position: 15
  org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2497)
```

oh-kay, so DB hasn't been setup yet .. so let me do that ::
- `test/yetibot/core/test/db.clj`
- `test/yetibot/core/test/parser.clj`

you will see me requiring that `db` NS -- and since the `loader` function is a `defonce` -- it will load the schema (yay for idempotent schema loading !!) .. i then proceed with running my tests -- again, only for a specific NS (`parser`) using `lein test` .. but then i need to solve the problem of making sure the commands i am testing are in fact loaded -- so i use the `load-ns` function to do that ..

at the end of it all, i have a "clean" way of mod'ing/testing a single core NS and test NS .. no issues, just the stuff ..

is this OK ?? is my brain not connecting synapsis ?? i get that we should be focusing on repl driven development, and i can do that for the most part -- but when i am thinking of how YB is tested, and issues i have ran into before (`yetibot_channel` not existing, unknown commands because they haven't been loaded, etc) -- it seems like this is a semi-OK way to making sure what i need prepared is in fact prepared ..

i don't think we have control over the ordering of what midje loads 1st, 2nd, etc .. and while i can't find the doc right this instance -- i am pretty sure i read that midje wants you to think of each fact as completely independent, isolated test units and that you should not depend on any specific loading order of said facts ..

anway -- just testing out some ideas i have about how to move forward with some testing i want to do .. open to any and all ideas ..

thanks !! no rush