### PR TITLE
offload use of heavy `(load-commands)` and declare expected commands in `(:require)`

### DIFF
--- a/src/yetibot/core/parser.clj
+++ b/src/yetibot/core/parser.clj
@@ -47,15 +47,15 @@
           head (first nodes)]
       ;; handle the AST nodes adcording to the type of tag
       (condp = tag
-        :cmd (apply str (map transformer nodes))
+        :cmd (join (map transformer nodes))
         ;; this is where the magic happens ✨
         ;; eval cmds in order of left to right (lazily)
         ;; piping the result of one to the next
         :expr (handle-expr #'transformer nodes)
         :words (join (map transformer nodes))
-        :space (apply str nodes)
-        :parened (apply str nodes)
-        :literal (apply str nodes)
+        :space (join nodes)
+        :parened (join nodes)
+        :literal (join nodes)
         :sub-expr (let [{:keys [value error] :as evaled}
                         (transformer head)]
                     ;; extract either the error or the value out of the sub-expr

--- a/test/yetibot/core/test/chat.clj
+++ b/test/yetibot/core/test/chat.clj
@@ -1,6 +1,7 @@
 (ns yetibot.core.test.chat
   (:require [midje.sweet :refer [facts fact => =not=> provided as-checker
                                  throws falsey contains]]
+            yetibot.core.test.db
             [clojure.string :as s]
             [yetibot.core.chat :as c]
             [yetibot.core.adapters.adapter :as a]))

--- a/test/yetibot/core/test/commands/cmd.clj
+++ b/test/yetibot/core/test/commands/cmd.clj
@@ -2,8 +2,8 @@
   (:require
    [midje.sweet :refer [fact =>]]
    [yetibot.core.commands.cmd :refer [cmd]]
-   [yetibot.core.loader :as loader]))
+   yetibot.core.test.db
+   yetibot.core.commands.echo))
 
 (fact "cmd should work as expected"
-      (loader/load-commands)
       (cmd {:match "echo hi"}) => "hi")

--- a/test/yetibot/core/test/commands/render.clj
+++ b/test/yetibot/core/test/commands/render.clj
@@ -2,7 +2,9 @@
   (:require [midje.sweet :refer [=> fact]]
             [yetibot.core.hooks :refer [cmd-hook]]
             [yetibot.core.midje :refer [error value]]
-            [yetibot.core.loader :as ldr]
+            yetibot.core.commands.render
+            yetibot.core.commands.collections
+            yetibot.core.commands.error
             [yetibot.core.util.command-info :refer [command-execution-info]]))
 
 (def execution-opts {:run-command? true
@@ -109,7 +111,6 @@
 
 (fact
  "errors are propagated in yetibot selmer filters"
- (ldr/load-commands)
  (:result
   (command-execution-info
    "render Score {{score}} - {{zip|yetibot:error}}"

--- a/test/yetibot/core/test/handler.clj
+++ b/test/yetibot/core/test/handler.clj
@@ -4,7 +4,8 @@
    [yetibot.core.handler :as h]
    [clojure.string :as s]
    [yetibot.core.interpreter :as i]
-   [yetibot.core.commands.echo]
+   yetibot.core.test.db
+   yetibot.core.commands.echo
    [yetibot.core.chat :refer [chat-data-structure *adapter*]]
    [clojure.core.async :refer [<!!]]))
 
@@ -22,7 +23,6 @@
 
 (fact
  "Newlines are preserved in command handling"
- ;;  (ldr/load-commands)
  (:value (h/handle-unparsed-expr (str "echo " multiline-str))) => multiline-str)
 
 (facts

--- a/test/yetibot/core/test/interpreter.clj
+++ b/test/yetibot/core/test/interpreter.clj
@@ -3,16 +3,15 @@
    [yetibot.core.interpreter :as i]
    [yetibot.core.models.default-command :refer [fallback-enabled?
                                                 configured-default-command]]
-   [yetibot.core.commands.help]
-   [yetibot.core.commands.echo]
-   [yetibot.core.parser]
+   yetibot.core.parser
+   yetibot.core.test.db
+   yetibot.core.commands.help
+   yetibot.core.commands.echo
    [midje.sweet :refer [=> provided contains against-background
-                        fact facts every-checker anything]]
-   [yetibot.core.loader :as ldr]))
+                        fact facts every-checker anything]]))
 
 (facts
  "about handle-cmd"
- (ldr/load-commands)
  (fact
   "handles legit echo command and returns command args"
   (i/handle-cmd "echo hello world" {}) => "hello world")
@@ -28,7 +27,6 @@
  (fact
   "non-legit command is picked up by the help command when it is loaded and
    returns some doc-strings for the help command."
-  (require 'yetibot.core.commands.help :reload)
   ;; forcing the help command to be the config'ed def cmd
   (against-background (configured-default-command) => "help")
   (let [cmd-result (i/handle-cmd "somerandom command" {})]
@@ -40,7 +38,6 @@
  (fact
   "legit echo command is issued incorrectly (echop); handle-cmd sees there is a legit
    similar command and throws it into the help command and gets back echo doc-string"
-  (require 'yetibot.core.commands.help :reload)
   (against-background (configured-default-command) => "help")
   (let [cmd-result (i/handle-cmd "echop" {})]
     cmd-result => coll?

--- a/test/yetibot/core/test/parser.clj
+++ b/test/yetibot/core/test/parser.clj
@@ -3,7 +3,9 @@
             [yetibot.core.unparser :refer [unparse]]
             [yetibot.core.parser :refer [parser parse-and-eval transformer]]
             yetibot.core.test.db
-            [yetibot.core.loader :refer [load-ns]]
+            yetibot.core.commands.echo
+            yetibot.core.commands.category
+            yetibot.core.commands.render
             [yetibot.core.interpreter :refer [handle-expr]]))
 
 (facts "single commands should be parsed"
@@ -229,13 +231,11 @@
  "about parse-and-eval"
  (fact
   "Commands can be piped in succession"
-  (load-ns 'yetibot.core.commands.echo)
   (:value (parse-and-eval "echo there | echo `echo hi`")) =>
   "hi there")
 
  (fact
   "Commands with data work as expected"
-  (load-ns 'yetibot.core.commands.category)
   (:data (parse-and-eval "category names")) =>
   {:async "commands that execute asynchronously"
    :broken
@@ -258,10 +258,6 @@
 
  (fact
   "Sub expressions can access the data propagated from the previous pipe"
- ;;
-  (load-ns 'yetibot.core.commands.category)
-  (load-ns 'yetibot.core.commands.echo)
-  (load-ns 'yetibot.core.commands.render)
   (:value (parse-and-eval
            "category names | echo async: `render {{async}}`")) =>
   "async: commands that execute asynchronously"
@@ -273,7 +269,6 @@
 
  (fact
   "Commands with literals can be transformed"
-  (load-ns 'yetibot.core.commands.echo)
   (:value (parse-and-eval "echo \"hi\"")) => "\"hi\""))
 
 (facts

--- a/test/yetibot/core/test/webapp/routes/graphql.clj
+++ b/test/yetibot/core/test/webapp/routes/graphql.clj
@@ -1,10 +1,10 @@
 (ns yetibot.core.test.webapp.routes.graphql
   (:require [yetibot.core.webapp.routes.graphql :refer [graphql]]
-            [yetibot.core.loader :as ldr]
+            yetibot.core.test.db
+            yetibot.core.commands.echo
             [midje.sweet :refer [=> =not=> fact facts contains]]))
 
 (facts
- (ldr/load-commands)
  "about graphql"
  (fact
   "can run a simple graphql query with expected results and no errors"


### PR DESCRIPTION
yes, major bikeshedding here, just trying to be more consistent and follow what kibit tells me

- `src/yetibot/core/parser.clj`
  - kibit told me to do this

- dropping heavy `(load-commands)` for something "lighter" and/or declaring tested bot commands in `(:require)`
  - `test/yetibot/core/test/commands/cmd.clj`
  - `test/yetibot/core/test/commands/render.clj`
  - `test/yetibot/core/test/handler.clj`
  - `test/yetibot/core/test/interpreter.clj`
  - `test/yetibot/core/test/webapp/routes/graphql.clj`

  - `test/yetibot/core/test/parser.clj`
    - no need for many uses of `(load-ns)` here, just use `(:require)`