### PR TITLE
fix: #1123 - Fixing issue with discord observors and reactions

### DIFF
--- a/src/yetibot/core/adapters/discord.clj
+++ b/src/yetibot/core/adapters/discord.clj
@@ -40,14 +40,15 @@
               user-model (assoc (users/get-user cs message-author-id)
                                 :yetibot? yetibot?)
               message-content (:content @(messaging/get-channel-message! rest-conn channel-id message-id))]
-          (handler/handle-raw
-           cs
-           user-model
-           :react
-           @yetibot-user
-           {:reaction emoji-name
-            :body message-content
-            :message-user message-author-id}))))))
+          (binding [chat/*target* (:channel-id event-data)]
+            (handler/handle-raw
+             cs
+             user-model
+             :react
+             @yetibot-user
+             {:reaction emoji-name
+              :body message-content
+              :message-user message-author-id})))))))
 
 
 (defmethod handle-event :message-create


### PR DESCRIPTION
As @devth pointed out, we were not binding the chat `target` for the reactions. 

[fix #1123](https://github.com/yetibot/yetibot/issues/1123)